### PR TITLE
Add template transform function to vite plugin

### DIFF
--- a/src/vite/observable.ts
+++ b/src/vite/observable.ts
@@ -4,8 +4,8 @@ import {dirname, join, resolve} from "node:path";
 import {fileURLToPath} from "node:url";
 import type {TemplateLiteral} from "acorn";
 import {JSDOM} from "jsdom";
-import type {PluginOption} from "vite";
-import type {Cell} from "../lib/notebook.js";
+import type {PluginOption, IndexHtmlTransformContext} from "vite";
+import type {Cell, Notebook} from "../lib/notebook.js";
 import {deserialize} from "../lib/serialize.js";
 import {Sourcemap} from "../javascript/sourcemap.js";
 import {transpile} from "../javascript/transpile.js";
@@ -13,6 +13,17 @@ import {parseTemplate} from "../javascript/template.js";
 import {collectAssets} from "../runtime/stdlib/assets.js";
 import {highlight} from "../runtime/stdlib/highlight.js";
 import {MarkdownRenderer} from "../runtime/stdlib/md.js";
+
+export interface TransformTemplateParams {
+  /** The template HTML to be transformed. */
+  template: string;
+  /** The notebook input. */
+  input: string;
+  /** Vite Hot Module Reload context. */
+  context: IndexHtmlTransformContext;
+  /** The parsed Observable Notebook */
+  notebook: Notebook;
+}
 
 export interface ObservableOptions {
   /** The global window, for the default parser and serializer implementations. */
@@ -23,13 +34,16 @@ export interface ObservableOptions {
   serializer?: XMLSerializer;
   /** The path to the page template; defaults to the default template. */
   template?: string;
+  /** A function which performs a per-page transformation of the template HTML. */
+  transformTemplate?: (params: TransformTemplateParams) => string;
 }
 
 export function observable({
   window = new JSDOM().window,
   parser = new window.DOMParser(),
   serializer = new window.XMLSerializer(),
-  template = fileURLToPath(import.meta.resolve("../templates/default.html"))
+  template = fileURLToPath(import.meta.resolve("../templates/default.html")),
+  transformTemplate = undefined
 }: ObservableOptions = {}): PluginOption {
   return {
     name: "observable",
@@ -45,7 +59,10 @@ export function observable({
       order: "pre",
       async handler(input, context) {
         const notebook = deserialize(input, {parser});
-        const tsource = await readFile(template, "utf-8");
+        let tsource = await readFile(template, "utf-8");
+        if (transformTemplate) {
+          tsource = transformTemplate({template: tsource, input, context, notebook});
+        }
         const document = parser.parseFromString(tsource, "text/html");
         const statics = new Set<Cell>();
         const assets = new Set<string>();


### PR DESCRIPTION
## Desired behavior

I would like to insert information obtained from either the notebook or from the notebook filename within the page template. This includes, for example, inserting a published-at date into the page, inserting meta tags with a description/title/image into the `<head>` element, or using an identifier to append a comments box.

## Actual behavior

The `template` argument of the `observable()` vite function only accepts a filename, making it difficult to customize per-page.

## Proposed solution

I've added a `transformTemplate()` function which receives… probably too much metadata about the notebook. This allows me to write my template as a Handlebars.js template and use the `transformTemplate()` function to compile the template, inserting page-dependent content into the template.

See: https://github.com/rreusser/notebooks/blob/c1b9efd5d5a3a21f24b9a96e2ac44eb7ec83bccc/vite.config.js#L25-L60

## Concerns

- It seems ad hoc to me, like what you get when someone without full context of what the API enables submitting a half-baked PR. 🙈 
- Perhaps this should live as a separate vite plugin, rather than shoehorning it into the Notebook Kit plugin.
- Perhaps this should make better use of the Notebook Kit API methods rather than just passing everything and the kitchen sink off to an arbitrary function.

At the end of the day, this PR is a shot in the dark since as a habit, I try to propose fixes rather than just requesting features. I won't take it hard if this isn't an acceptable approach though. I'm glad to follow through and add tests/docs, or just bail on this and take a different approach entirely. Notebooks 2.0 is *outstanding* so far.

