### PR TITLE
Transform notebook

### DIFF
--- a/src/vite/observable.ts
+++ b/src/vite/observable.ts
@@ -52,7 +52,7 @@ export function observable({
       async handler(input, context) {
         let notebook = deserialize(input, {parser});
         if (transformNotebook !== undefined) {
-          notebook = await transformNotebook(structuredClone(notebook), context);
+          notebook = await transformNotebook(notebook, context);
         }
         let tsource = await readFile(template, "utf-8");
         if (transformTemplate !== undefined) {

--- a/src/vite/observable.ts
+++ b/src/vite/observable.ts
@@ -26,7 +26,7 @@ export interface ObservableOptions {
   /** A function which performs a per-page transformation of the template HTML. */
   transformTemplate?: (template: string, context: IndexHtmlTransformContext) => string | Promise<string>;
   /** A function which mutates the parsed notebook. */
-  transformNotebook?: (input: Notebook, context: IndexHtmlTransformContext) => Notebook | Promise<Notebook>;
+  transformNotebook?: (notebook: Notebook, context: IndexHtmlTransformContext) => Notebook | Promise<Notebook>;
 }
 
 export function observable({


### PR DESCRIPTION
Following #30, This PR adds a `transformNotebook` function to the Observable Vite plugin which allows you to modify the parsed notebook during build. A sample use case of this is to modify or remove the title heading, replacing it with something else.[^1] I'm sure there are many interesting and also some less reputable use-cases. It's niche, but when it's useful, it's seems useful.

[^1]: The particular reason why removing the in-notebook heading was desirable for me is silly: I wanted the content to be 640px wide, but then the header was not full-bleed, and I didn't want to widen the `main` notebook element and then have to compensate by re-narrowing all cells except the header. I ended up using pseudo-elements transformed to make the header run off the page and *look* full-bleed, which worked, but it was a mess.