### PR TITLE
Update observable.tmpl

### DIFF
--- a/docs/observable.tmpl
+++ b/docs/observable.tmpl
@@ -47,7 +47,7 @@
     </header>
     <main style="min-height: calc(100vh - 20rem);"></main>
     <div style="margin: 12rem 0 2rem; font: 500 14px/normal var(--sans-serif);">
-      <a id="edit-page" href="https://github.com/observablehq/notebook-kit">
+      <a id="edit-page" href="https://github.com/observablehq">
         ✎ Suggest changes to this page
       </a>
     </div>

--- a/docs/observable.tmpl
+++ b/docs/observable.tmpl
@@ -47,12 +47,12 @@
     </header>
     <main style="min-height: calc(100vh - 20rem);"></main>
     <div style="margin: 12rem 0 2rem; font: 500 14px/normal var(--sans-serif);">
-      <a id="edit-page" href="https://github.com/observablehq">
+      <a id="edit-page" href="https://github.com/observablehq/notebook-kit">
         ✎ Suggest changes to this page
       </a>
     </div>
     <script type="module">
-      document.querySelector("#edit-page").href += `/edit/main/docs${location.pathname + (location.pathname.endsWith("/") ? "index" : "")}.html`;
+      document.querySelector("#edit-page").href += `/edit/main/docs${location.pathname.replace(/^\/notebook-kit\//, "/") + (location.pathname.endsWith("/") ? "index" : "")}.html`;
     </script>
     <footer style="width: 100vw; margin: 2rem calc((100% - 100vw) / 2) -32px; padding-bottom: 16px; background-color: var(--theme-foreground); color: var(--theme-background); font: 12px/normal var(--sans-serif);">
       <div style="display: flex; flex-wrap: wrap; max-width: var(--max-width); padding: 2rem 1rem; margin: auto; gap: 2rem;">

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "tsc --noEmit && eslint bin src types",
     "notebooks": "tsx bin/notebooks.ts",
     "download": "tsx bin/notebooks.ts download",
-    "docs:preview": "tsx --watch bin/notebooks.ts preview --root docs --template docs/observable.tmpl",
+    "docs:preview": "tsx --watch bin/notebooks.ts preview --base /notebook-kit/ --root docs --template docs/observable.tmpl",
     "docs:build": "tsx bin/notebooks.ts build --root docs --template docs/observable.tmpl -- $(find docs -path 'docs/.observable' -prune -o -name '*.html' -print)"
   },
   "bin": {


### PR DESCRIPTION
The "suggest changes" links at the bottom of the docs pages are not working. It places an additional `/notebook-kit` into the url. 

This removes `notebook-kit` from the base url since the `location.pathname` already has `notebook-kit` in it.