### PR TITLE
BigQuery connector: dataset option

### DIFF
--- a/docs/databases.html
+++ b/docs/databases.html
@@ -280,8 +280,11 @@
       keyFilename?: string;
       keyFile?: string;
       projectId?: string;
+      dataset?: string;
     }
     ```
+
+    Setting `dataset` makes unqualified table references in SQL cells resolve against that dataset, mirroring the `bq` CLI's `--dataset_id`.
 
     See the [Google Cloud SDK documentation](https://cloud.google.com/docs/authentication/set-up-adc-local-dev-environment) for details.
   </script>

--- a/src/databases/bigquery.ts
+++ b/src/databases/bigquery.ts
@@ -10,14 +10,19 @@ export type BigQueryConfig = {
   keyFilename?: string;
   keyFile?: string;
   projectId?: string;
+  dataset?: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export default function bigquery({type, ...options}: BigQueryConfig): QueryTemplateFunction {
+export default function bigquery({type, dataset, ...options}: BigQueryConfig): QueryTemplateFunction {
   return async (strings, ...params) => {
     const bigquery = new BigQuery(options);
     const date = new Date();
-    const [job] = await bigquery.createQueryJob({query: strings.join("?"), params});
+    const [job] = await bigquery.createQueryJob({
+      query: strings.join("?"),
+      params,
+      ...(dataset && {defaultDataset: {datasetId: dataset}}),
+    });
     const [rows, , response] = await job.getQueryResults();
     return {rows, schema: getTableSchema(response!.schema!), duration: Date.now() - +date, date};
   };


### PR DESCRIPTION
## Rationale

`BigQueryConfig` in `src/databases/bigquery.ts` has no way to specify a dataset, so SQL cells must fully qualify every table reference, for example: `SELECT ... FROM project.dataset.table ...`

## Implementation

BQ client already supports it: `BigQuery#createQueryJob` accepts `defaultDataset` field per [Jobs resource](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job). Similarly `bq` CLI exposes same as `--dataset_id`.

This PR adds `dataset?: string` to `BigQueryConfig` and forwards it to `createQueryJob` as `{defaultDataset: {datasetId: dataset}}`. If this option is not specified, original behavior is maintained.

Docs in `docs/databases.html` updated to match.

We're running this patch in our app, it works as expected.