### PR TITLE
fix node interpolation into md

### DIFF
--- a/src/runtime/stdlib/md.ts
+++ b/src/runtime/stdlib/md.ts
@@ -22,18 +22,18 @@ export function MarkdownRenderer({
     let partIndex = -1;
     const parts: Node[] = [];
 
-    // Concatenate the text using comments as placeholders.
+    // Concatenate the text using anchors as placeholders.
     for (let i = 0, n = values.length; i < n; ++i) {
       const value = values[i];
       if (value instanceof Node) {
         parts[++partIndex] = value;
-        source += `<!--o:${partIndex}-->`;
+        source += `<a id=o:${partIndex}></a>`;
       } else if (Array.isArray(value)) {
         for (const node of value) {
           if (node instanceof Node) {
             if (fragment === null) {
               parts[++partIndex] = fragment = document.createDocumentFragment();
-              source += `<!--o:${partIndex}-->`;
+              source += `<a id=o:${partIndex}></a>`;
             }
             fragment.appendChild(node);
           } else {
@@ -52,14 +52,12 @@ export function MarkdownRenderer({
     const root = document.createElement("div");
     root.innerHTML = mi.render(source);
 
-    // Walk the rendered content to replace comment placeholders.
+    // Walk the rendered content to replace anchor placeholders.
     if (++partIndex > 0) {
-      const nodes = new Array<Comment>(partIndex);
-      const walker = document.createTreeWalker(root, NodeFilter.SHOW_COMMENT, null);
-      while (walker.nextNode()) {
-        const node = walker.currentNode as Comment;
-        if (/^o:\d+$/.test(node.nodeValue!)) {
-          nodes[+node.nodeValue!.slice(2)] = node;
+      const nodes = new Array<Element>(partIndex);
+      for (const node of root.querySelectorAll("a[id^='o:']")) {
+        if (/^o:\d+$/.test(node.id!)) {
+          nodes[+node.id!.slice(2)] = node;
         }
       }
       for (let i = 0; i < partIndex; ++i) {


### PR DESCRIPTION
The `md` tagged template literal uses comments as placeholders for inserting dynamic content (such as interpolated HTML elements) into the rendered Markdown. Unfortunately, unlike HTML, Markdown treats comments as HTML block elements rather than HTML inline elements, potentially changing the semantics of the adjacent Markdown. Therefore we need to use an HTML element for the placeholder that Markdown recognizes as an inline element, which is a small set of things like `<a>`, `<span>`, `<em>`, and a few more. I’ve chosen `<a>` here.

Here is a test of what should work:

```md
- ${html`foo`} is **bold**
- ${html`bar`} is _italic_
```

This erroneously produces:

<img width="444" height="148" alt="Screenshot 2026-05-06 at 6 26 11 PM" src="https://github.com/user-attachments/assets/83ab83ea-3e7c-4aad-943f-b97916009abb" />

I tested the fixed implementation here manually in a notebook. 🤷 