### PR TITLE
md test

### DIFF
--- a/src/runtime/stdlib/md.test.ts
+++ b/src/runtime/stdlib/md.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import {describe, expect, test} from "vitest";
+import {MarkdownRenderer} from "./md.js";
+
+describe("MarkdownRenderer", () => {
+  test("uses inline elements for node interpolation", () => {
+    const md = MarkdownRenderer();
+    const foo = document.createElement("span");
+    foo.textContent = "foo";
+    const bar = document.createElement("span");
+    bar.textContent = "bar";
+
+    const result = md`- ${foo} is **bold**\n- ${bar} is _italic_`;
+
+    expect(result.innerHTML).toMatchInlineSnapshot(`
+      "<ul>
+      <li><span>foo</span> is <strong>bold</strong></li>
+      <li><span>bar</span> is <em>italic</em></li>
+      </ul>
+      "
+    `);
+  });
+});


### PR DESCRIPTION
adds a test for #135 (node interpolation into md)

(it could be used as a template to add more md tests with inline snapshots when we want)

checked that it failed before and succeeds after 41c3a43b00294778ff218822a3c219b5f899d161