### PR TITLE
xlsx tests

### DIFF
--- a/src/runtime/stdlib/xlsx.test.ts
+++ b/src/runtime/stdlib/xlsx.test.ts
@@ -15,14 +15,23 @@ function createWorkbook(sheets: Record<string, ExcelJS.CellValue[][]>) {
   return new Workbook(workbook);
 }
 
-// Sheets are decorated with a `.columns` property
-expect.addEqualityTesters([
-  function (a, b) {
-    return !Array.isArray(a) || !Array.isArray(b)
-      ? undefined // pass
-      : this.equals(a, b) && this.equals(Reflect.get(a, "columns"), Reflect.get(b, "columns")); // test all arrays
+declare module "vitest" {
+  interface Matchers {
+    toBeSheet: (sheet: Record<string, ExcelJS.CellValue>[] & {columns: string[]}) => unknown;
   }
-]);
+}
+
+// Sheets are decorated with a `.columns` property
+expect.extend({
+  toBeSheet(a, b) {
+    return {
+      pass: this.equals(a, b) && this.equals(Reflect.get(a, "columns"), Reflect.get(b, "columns")),
+      message: () => `expected sheet to${this.isNot ? " not" : ""} be`,
+      actual: a,
+      expected: b
+    };
+  }
+});
 
 describe("FileAttachment.xlsx", () => {
   test("reads sheet names", () => {
@@ -42,16 +51,16 @@ describe("FileAttachment.xlsx", () => {
         [1, 2, 3]
       ]
     });
-    expect(workbook.sheet(0)).toEqual(
+    expect(workbook.sheet(0)).toBeSheet(
       Object.assign(
         [
-          {A: "one", B: "two", C: "three"},
+          {A: "one!", B: "two", C: "three"},
           {A: 1, B: 2, C: 3}
         ],
         {columns: [..."#ABC"]}
       )
     );
-    expect(workbook.sheet("Sheet1")).toEqual(
+    expect(workbook.sheet("Sheet1")).toBeSheet(
       Object.assign(
         [
           {A: "one", B: "two", C: "three"},
@@ -75,7 +84,7 @@ describe("FileAttachment.xlsx", () => {
         [new Date(Date.UTC(2020, 0, 1)), {} as unknown as ExcelJS.CellValue]
       ]
     });
-    expect(workbook.sheet(0)).toEqual(
+    expect(workbook.sheet(0)).toBeSheet(
       Object.assign(
         [
           {},
@@ -100,7 +109,7 @@ describe("FileAttachment.xlsx", () => {
         ]
       ]
     });
-    expect(workbook.sheet(0)).toEqual(
+    expect(workbook.sheet(0)).toBeSheet(
       Object.assign(
         [
           {
@@ -126,7 +135,7 @@ describe("FileAttachment.xlsx", () => {
         ]
       ]
     });
-    expect(workbook.sheet(0)).toEqual(
+    expect(workbook.sheet(0)).toBeSheet(
       Object.assign([{B: "https://example.com [object Object]"}], {columns: [..."#AB"]})
     );
   });
@@ -141,7 +150,7 @@ describe("FileAttachment.xlsx", () => {
         ]
       ]
     });
-    expect(workbook.sheet(0)).toEqual(
+    expect(workbook.sheet(0)).toBeSheet(
       Object.assign([{A: 10, B: 12, C: NaN}], {
         columns: [..."#ABC"]
       })
@@ -156,7 +165,7 @@ describe("FileAttachment.xlsx", () => {
         [6, 7, 8, 9, 10]
       ]
     });
-    expect(workbook.sheet(0, {headers: true})).toEqual(
+    expect(workbook.sheet(0, {headers: true})).toBeSheet(
       Object.assign(
         [
           {A: 1, one_: 3, two: 4, A_: 5, 0: "zero"},
@@ -198,11 +207,11 @@ describe("FileAttachment.xlsx", () => {
       ],
       {columns: [..."#ABCDEFGHIJ"]}
     );
-    expect(workbook.sheet(0)).toEqual(entireSheet);
-    expect(workbook.sheet(0, {range: ":"})).toEqual(entireSheet);
+    expect(workbook.sheet(0)).toBeSheet(entireSheet);
+    expect(workbook.sheet(0, {range: ":"})).toBeSheet(entireSheet);
 
     // "B2:C3"
-    expect(workbook.sheet(0, {range: "B2:C3"})).toEqual(
+    expect(workbook.sheet(0, {range: "B2:C3"})).toBeSheet(
       Object.assign(
         [
           {B: 11, C: 12},
@@ -213,7 +222,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // ":C3"
-    expect(workbook.sheet(0, {range: ":C3"})).toEqual(
+    expect(workbook.sheet(0, {range: ":C3"})).toBeSheet(
       Object.assign(
         [
           {A: 0, B: 1, C: 2},
@@ -225,7 +234,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // "B2:"
-    expect(workbook.sheet(0, {range: "B2:"})).toEqual(
+    expect(workbook.sheet(0, {range: "B2:"})).toBeSheet(
       Object.assign(
         [
           {B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
@@ -237,7 +246,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // "H:"
-    expect(workbook.sheet(0, {range: "H:"})).toEqual(
+    expect(workbook.sheet(0, {range: "H:"})).toBeSheet(
       Object.assign(
         [
           {H: 7, I: 8, J: 9},
@@ -250,7 +259,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // ":C"
-    expect(workbook.sheet(0, {range: ":C"})).toEqual(
+    expect(workbook.sheet(0, {range: ":C"})).toBeSheet(
       Object.assign(
         [
           {A: 0, B: 1, C: 2},
@@ -263,19 +272,19 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // ":Z"
-    expect(workbook.sheet(0, {range: ":Z"})).toEqual(
+    expect(workbook.sheet(0, {range: ":Z"})).toBeSheet(
       Object.assign(entireSheet.slice(), {
         columns: [..."#ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
       })
     );
 
     // "2:"
-    expect(workbook.sheet(0, {range: "2:"})).toEqual(
+    expect(workbook.sheet(0, {range: "2:"})).toBeSheet(
       Object.assign(entireSheet.slice(1), {columns: entireSheet.columns})
     );
 
     // ":2"
-    expect(workbook.sheet(0, {range: ":2"})).toEqual(
+    expect(workbook.sheet(0, {range: ":2"})).toBeSheet(
       Object.assign(entireSheet.slice(0, 2), {columns: entireSheet.columns})
     );
   });

--- a/src/runtime/stdlib/xlsx.test.ts
+++ b/src/runtime/stdlib/xlsx.test.ts
@@ -3,7 +3,7 @@ import {assert, describe, expect, test, vi} from "vitest";
 import {Workbook} from "./xlsx.js";
 
 // Route exceljs to the version from devDependencies
-vi.mock("https://cdn.jsdelivr.net/npm/exceljs/+esm", async () => await import("exceljs"));
+vi.mock("https://cdn.jsdelivr.net/npm/exceljs/+esm", async () => import("exceljs"));
 
 declare module "vitest" {
   interface Matchers {

--- a/src/runtime/stdlib/xlsx.test.ts
+++ b/src/runtime/stdlib/xlsx.test.ts
@@ -1,19 +1,9 @@
 import ExcelJS from "exceljs";
 import {assert, describe, expect, test, vi} from "vitest";
+import {Workbook} from "./xlsx.js";
 
 // Route exceljs to the version from devDependencies
 vi.mock("https://cdn.jsdelivr.net/npm/exceljs/+esm", async () => await import("exceljs"));
-
-const {Workbook} = await import("./xlsx.js");
-
-function createWorkbook(sheets: Record<string, ExcelJS.CellValue[][]>) {
-  const workbook = new ExcelJS.Workbook();
-  for (const [sheet, rows] of Object.entries(sheets)) {
-    const ws = workbook.addWorksheet(sheet);
-    for (const row of rows) ws.addRow(row);
-  }
-  return new Workbook(workbook);
-}
 
 declare module "vitest" {
   interface Matchers {
@@ -32,6 +22,15 @@ expect.extend({
     };
   }
 });
+
+function createWorkbook(sheets: Record<string, ExcelJS.CellValue[][]>) {
+  const workbook = new ExcelJS.Workbook();
+  for (const [sheet, rows] of Object.entries(sheets)) {
+    const ws = workbook.addWorksheet(sheet);
+    for (const row of rows) ws.addRow(row);
+  }
+  return new Workbook(workbook);
+}
 
 describe("FileAttachment.xlsx", () => {
   test("reads sheet names", () => {
@@ -54,7 +53,7 @@ describe("FileAttachment.xlsx", () => {
     expect(workbook.sheet(0)).toBeSheet(
       Object.assign(
         [
-          {A: "one!", B: "two", C: "three"},
+          {A: "one", B: "two", C: "three"},
           {A: 1, B: 2, C: 3}
         ],
         {columns: [..."#ABC"]}

--- a/src/runtime/stdlib/xlsx.test.ts
+++ b/src/runtime/stdlib/xlsx.test.ts
@@ -9,22 +9,20 @@ type Row = Record<string, ExcelJS.CellValue>;
 
 declare module "vitest" {
   interface Matchers {
-    toBeSheet: (sheet: Row[] & {columns: string[]}) => unknown;
+    toBeSheet: (rows: Row[], columns: string[]) => unknown;
   }
 }
 
 // Sheets are decorated with a `.columns` property
 expect.extend({
-  toBeSheet(a, b) {
-    a = Object.assign(
-      Array.from(a, (row: Row) => ({"#": row["#"], ...row})),
-      {columns: a.columns}
-    );
+  toBeSheet(actual, rows, columns) {
+    const actualRows = Array.from(actual, (row: Row) => ({"#": row["#"], ...row}));
+    const actualColumns = actual.columns;
     return {
-      pass: this.equals(a, b),
+      pass: this.equals(actualRows, rows) && this.equals(actualColumns, columns),
       message: () => `expected sheet to${this.isNot ? " not" : ""} be`,
-      actual: a,
-      expected: b
+      actual: {rows: actualRows, columns: actualColumns},
+      expected: {rows, columns}
     };
   }
 });
@@ -57,22 +55,18 @@ describe("FileAttachment.xlsx", () => {
       ]
     });
     expect(workbook.sheet(0)).toBeSheet(
-      Object.assign(
-        [
-          {"#": 1, A: "one", B: "two", C: "three"},
-          {"#": 2, A: 1, B: 2, C: 3}
-        ],
-        {columns: [..."#ABC"]}
-      )
+      [
+        {"#": 1, A: "one", B: "two", C: "three"},
+        {"#": 2, A: 1, B: 2, C: 3}
+      ],
+      [..."#ABC"]
     );
     expect(workbook.sheet("Sheet1")).toBeSheet(
-      Object.assign(
-        [
-          {"#": 1, A: "one", B: "two", C: "three"},
-          {"#": 2, A: 1, B: 2, C: 3}
-        ],
-        {columns: [..."#ABC"]}
-      )
+      [
+        {"#": 1, A: "one", B: "two", C: "three"},
+        {"#": 2, A: 1, B: 2, C: 3}
+      ],
+      [..."#ABC"]
     );
   });
 
@@ -88,17 +82,15 @@ describe("FileAttachment.xlsx", () => {
       ]
     });
     expect(workbook.sheet(0)).toBeSheet(
-      Object.assign(
-        [
-          {"#": 1},
-          {"#": 2},
-          {"#": 3, A: "hello", B: "", C: "0", D: "1"},
-          {"#": 4, A: 1, B: 1.2},
-          {"#": 5, A: true, B: false},
-          {"#": 6, A: new Date(Date.UTC(2020, 0, 1))} // unknown shapes drop
-        ],
-        {columns: [..."#ABCD"]}
-      )
+      [
+        {"#": 1},
+        {"#": 2},
+        {"#": 3, A: "hello", B: "", C: "0", D: "1"},
+        {"#": 4, A: 1, B: 1.2},
+        {"#": 5, A: true, B: false},
+        {"#": 6, A: new Date(Date.UTC(2020, 0, 1))} // unknown shapes drop
+      ],
+      [..."#ABCD"]
     );
   });
 
@@ -113,17 +105,15 @@ describe("FileAttachment.xlsx", () => {
       ]
     });
     expect(workbook.sheet(0)).toBeSheet(
-      Object.assign(
-        [
-          {
-            "#": 1,
-            A: "twothree",
-            B: `https://example.com?q=" link&</a>"'?`,
-            C: "https://example.com"
-          }
-        ],
-        {columns: [..."#ABC"]}
-      )
+      [
+        {
+          "#": 1,
+          A: "twothree",
+          B: `https://example.com?q=" link&</a>"'?`,
+          C: "https://example.com"
+        }
+      ],
+      [..."#ABC"]
     );
   });
 
@@ -136,9 +126,7 @@ describe("FileAttachment.xlsx", () => {
         ]
       ]
     });
-    expect(workbook.sheet(0)).toBeSheet(
-      Object.assign([{"#": 1, A: "", B: "text"}], {columns: [..."#AB"]})
-    );
+    expect(workbook.sheet(0)).toBeSheet([{"#": 1, A: "", B: "text"}], [..."#AB"]);
   });
 
   test("reads formulas", () => {
@@ -151,11 +139,7 @@ describe("FileAttachment.xlsx", () => {
         ]
       ]
     });
-    expect(workbook.sheet(0)).toBeSheet(
-      Object.assign([{"#": 1, A: 10, B: 12, C: NaN}], {
-        columns: [..."#ABC"]
-      })
-    );
+    expect(workbook.sheet(0)).toBeSheet([{"#": 1, A: 10, B: 12, C: NaN}], [..."#ABC"]);
   });
 
   test("reads sheets with headers", () => {
@@ -167,13 +151,11 @@ describe("FileAttachment.xlsx", () => {
       ]
     });
     expect(workbook.sheet(0, {headers: true})).toBeSheet(
-      Object.assign(
-        [
-          {"#": 2, A: 1, one_: 3, two: 4, A_: 5, 0: "zero"},
-          {"#": 3, A: 6, one: 7, one_: 8, two: 9, A_: 10}
-        ],
-        {columns: ["#", "A", "one", "one_", "two", "A_", "0"]}
-      )
+      [
+        {"#": 2, A: 1, one_: 3, two: 4, A_: 5, 0: "zero"},
+        {"#": 3, A: 6, one: 7, one_: 8, two: 9, A_: 10}
+      ],
+      ["#", "A", "one", "one_", "two", "A_", "0"]
     );
   });
 
@@ -199,95 +181,75 @@ describe("FileAttachment.xlsx", () => {
     });
 
     // undefined / ":"
-    const entireSheet = Object.assign(
-      [
-        {"#": 1, A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9},
-        {"#": 2, A: 10, B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
-        {"#": 3, A: 20, B: 21, C: 22, D: 23, E: 24, F: 25, G: 26, H: 27, I: 28, J: 29},
-        {"#": 4, A: 30, B: 31, C: 32, D: 33, E: 34, F: 35, G: 36, H: 37, I: 38, J: 39}
-      ],
-      {columns: [..."#ABCDEFGHIJ"]}
-    );
-    expect(workbook.sheet(0)).toBeSheet(entireSheet);
-    expect(workbook.sheet(0, {range: ":"})).toBeSheet(entireSheet);
+    const rows = [
+      {"#": 1, A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9},
+      {"#": 2, A: 10, B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
+      {"#": 3, A: 20, B: 21, C: 22, D: 23, E: 24, F: 25, G: 26, H: 27, I: 28, J: 29},
+      {"#": 4, A: 30, B: 31, C: 32, D: 33, E: 34, F: 35, G: 36, H: 37, I: 38, J: 39}
+    ];
+    const columns = [..."#ABCDEFGHIJ"];
+    expect(workbook.sheet(0)).toBeSheet(rows, columns);
+    expect(workbook.sheet(0, {range: ":"})).toBeSheet(rows, columns);
 
     // "B2:C3"
     expect(workbook.sheet(0, {range: "B2:C3"})).toBeSheet(
-      Object.assign(
-        [
-          {"#": 2, B: 11, C: 12},
-          {"#": 3, B: 21, C: 22}
-        ],
-        {columns: [..."#BC"]}
-      )
+      [
+        {"#": 2, B: 11, C: 12},
+        {"#": 3, B: 21, C: 22}
+      ],
+      [..."#BC"]
     );
 
     // ":C3"
     expect(workbook.sheet(0, {range: ":C3"})).toBeSheet(
-      Object.assign(
-        [
-          {"#": 1, A: 0, B: 1, C: 2},
-          {"#": 2, A: 10, B: 11, C: 12},
-          {"#": 3, A: 20, B: 21, C: 22}
-        ],
-        {columns: [..."#ABC"]}
-      )
+      [
+        {"#": 1, A: 0, B: 1, C: 2},
+        {"#": 2, A: 10, B: 11, C: 12},
+        {"#": 3, A: 20, B: 21, C: 22}
+      ],
+      [..."#ABC"]
     );
 
     // "B2:"
     expect(workbook.sheet(0, {range: "B2:"})).toBeSheet(
-      Object.assign(
-        [
-          {"#": 2, B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
-          {"#": 3, B: 21, C: 22, D: 23, E: 24, F: 25, G: 26, H: 27, I: 28, J: 29},
-          {"#": 4, B: 31, C: 32, D: 33, E: 34, F: 35, G: 36, H: 37, I: 38, J: 39}
-        ],
-        {columns: [..."#BCDEFGHIJ"]}
-      )
+      [
+        {"#": 2, B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
+        {"#": 3, B: 21, C: 22, D: 23, E: 24, F: 25, G: 26, H: 27, I: 28, J: 29},
+        {"#": 4, B: 31, C: 32, D: 33, E: 34, F: 35, G: 36, H: 37, I: 38, J: 39}
+      ],
+      [..."#BCDEFGHIJ"]
     );
 
     // "H:"
     expect(workbook.sheet(0, {range: "H:"})).toBeSheet(
-      Object.assign(
-        [
-          {"#": 1, H: 7, I: 8, J: 9},
-          {"#": 2, H: 17, I: 18, J: 19},
-          {"#": 3, H: 27, I: 28, J: 29},
-          {"#": 4, H: 37, I: 38, J: 39}
-        ],
-        {columns: ["#", "H", "I", "J"]}
-      )
+      [
+        {"#": 1, H: 7, I: 8, J: 9},
+        {"#": 2, H: 17, I: 18, J: 19},
+        {"#": 3, H: 27, I: 28, J: 29},
+        {"#": 4, H: 37, I: 38, J: 39}
+      ],
+      ["#", "H", "I", "J"]
     );
 
     // ":C"
     expect(workbook.sheet(0, {range: ":C"})).toBeSheet(
-      Object.assign(
-        [
-          {"#": 1, A: 0, B: 1, C: 2},
-          {"#": 2, A: 10, B: 11, C: 12},
-          {"#": 3, A: 20, B: 21, C: 22},
-          {"#": 4, A: 30, B: 31, C: 32}
-        ],
-        {columns: ["#", "A", "B", "C"]}
-      )
+      [
+        {"#": 1, A: 0, B: 1, C: 2},
+        {"#": 2, A: 10, B: 11, C: 12},
+        {"#": 3, A: 20, B: 21, C: 22},
+        {"#": 4, A: 30, B: 31, C: 32}
+      ],
+      ["#", "A", "B", "C"]
     );
 
     // ":Z"
-    expect(workbook.sheet(0, {range: ":Z"})).toBeSheet(
-      Object.assign(entireSheet.slice(), {
-        columns: [..."#ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
-      })
-    );
+    expect(workbook.sheet(0, {range: ":Z"})).toBeSheet(rows, [..."#ABCDEFGHIJKLMNOPQRSTUVWXYZ"]);
 
     // "2:"
-    expect(workbook.sheet(0, {range: "2:"})).toBeSheet(
-      Object.assign(entireSheet.slice(1), {columns: entireSheet.columns})
-    );
+    expect(workbook.sheet(0, {range: "2:"})).toBeSheet(rows.slice(1), columns);
 
     // ":2"
-    expect(workbook.sheet(0, {range: ":2"})).toBeSheet(
-      Object.assign(entireSheet.slice(0, 2), {columns: entireSheet.columns})
-    );
+    expect(workbook.sheet(0, {range: ":2"})).toBeSheet(rows.slice(0, 2), columns);
   });
 
   test("derives column names such as A AA AAA…", () => {

--- a/src/runtime/stdlib/xlsx.test.ts
+++ b/src/runtime/stdlib/xlsx.test.ts
@@ -6,7 +6,7 @@ vi.mock("https://cdn.jsdelivr.net/npm/exceljs/+esm", async () => await import("e
 
 const {Workbook} = await import("./xlsx.js");
 
-function exceljs(contents: Record<string, unknown[][]>): ExcelJS.Workbook {
+function exceljs(contents: Record<string, ExcelJS.CellValue[][]>): ExcelJS.Workbook {
   const workbook = new ExcelJS.Workbook();
   for (const [sheet, rows] of Object.entries(contents)) {
     const ws = workbook.addWorksheet(sheet);
@@ -69,7 +69,7 @@ describe("FileAttachment.xlsx", () => {
             ["hello", "", "0", "1"],
             [1, 1.2],
             [true, false],
-            [new Date(Date.UTC(2020, 0, 1)), {}]
+            [new Date(Date.UTC(2020, 0, 1)), {} as unknown as ExcelJS.CellValue]
           ]
         })
       ).sheet(0),
@@ -94,17 +94,8 @@ describe("FileAttachment.xlsx", () => {
           Sheet1: [
             [
               {richText: [{text: "two"}, {text: "three"}]}, // A
-              {text: "plain text"}, // B
-              {text: "https://example.com", hyperlink: "https://example.com"}, // C
-              {
-                text: {richText: [{text: "https://example.com"}]},
-                hyperlink: "https://example.com"
-              }, // D
-              {text: `link&</a>"'?`, hyperlink: 'https://example.com?q="'}, // E
-              {
-                text: {richText: [{text: "first"}, {text: "second"}]},
-                hyperlink: "https://example.com"
-              } // F
+              {text: `link&</a>"'?`, hyperlink: 'https://example.com?q="'}, // B
+              {text: "https://example.com", hyperlink: "https://example.com"} // C, text===hyperlink
             ]
           ]
         })
@@ -113,15 +104,31 @@ describe("FileAttachment.xlsx", () => {
         [
           {
             A: "twothree",
-            B: "plain text",
-            C: "https://example.com",
-            D: "https://example.com",
-            E: `https://example.com?q=" link&</a>"'?`,
-            F: "https://example.com firstsecond"
+            B: `https://example.com?q=" link&</a>"'?`,
+            C: "https://example.com"
           }
         ],
-        {columns: [..."#ABCDEF"]}
+        {columns: [..."#ABC"]}
       )
+    );
+  });
+
+  test("fails on malformed hyperlinks", () => {
+    assert.deepEqual(
+      new Workbook(
+        exceljs({
+          Sheet1: [
+            [
+              {text: "plain text"} as unknown as ExcelJS.CellValue, // A (drop)
+              {
+                text: {richText: [{text: "https://example.com"}]},
+                hyperlink: "https://example.com"
+              } as unknown as ExcelJS.CellValue // B
+            ]
+          ]
+        })
+      ).sheet(0),
+      Object.assign([{B: "https://example.com [object Object]"}], {columns: [..."#AB"]})
     );
   });
 
@@ -291,11 +298,7 @@ describe("FileAttachment.xlsx", () => {
 
   test("derives column names such as A AA AAA…", () => {
     const l0 = 26 * 26 * 23;
-    const workbook = new Workbook(
-      exceljs({
-        Sheet1: [Array.from({length: l0}).fill(1)]
-      })
-    );
+    const workbook = new Workbook(exceljs({Sheet1: [Array.from<number>({length: l0}).fill(1)]}));
     assert.deepStrictEqual(
       workbook.sheet(0).columns.filter((d: string) => d.match(/^A+$/)),
       ["A", "AA", "AAA"]
@@ -303,7 +306,9 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("headers protects __proto__ of row objects", () => {
-    const workbook = new Workbook(exceljs({Sheet1: [["__proto__"], [{a: 1}]]}));
+    const workbook = new Workbook(
+      exceljs({Sheet1: [["__proto__"], [{a: 1} as unknown as ExcelJS.CellValue]]})
+    );
     assert.notStrictEqual(workbook.sheet(0, {headers: true})[0].a, 1);
   });
 });

--- a/src/runtime/stdlib/xlsx.test.ts
+++ b/src/runtime/stdlib/xlsx.test.ts
@@ -1,0 +1,309 @@
+import ExcelJS from "exceljs";
+import {assert, describe, test, vi} from "vitest";
+
+// Route exceljs to the version from devDependencies
+vi.mock("https://cdn.jsdelivr.net/npm/exceljs/+esm", async () => await import("exceljs"));
+
+const {Workbook} = await import("./xlsx.js");
+
+function exceljs(contents: Record<string, unknown[][]>): ExcelJS.Workbook {
+  const workbook = new ExcelJS.Workbook();
+  for (const [sheet, rows] of Object.entries(contents)) {
+    const ws = workbook.addWorksheet(sheet);
+    for (const row of rows) ws.addRow(row);
+  }
+  return workbook;
+}
+
+describe("FileAttachment.xlsx", () => {
+  test("reads sheet names", () => {
+    const workbook = new Workbook(exceljs({Sheet1: []}));
+    assert.deepStrictEqual(workbook.sheetNames, ["Sheet1"]);
+  });
+
+  test("sheet(name) throws on unknown sheet name", () => {
+    const workbook = new Workbook(exceljs({Sheet1: []}));
+    assert.throws(() => workbook.sheet("bad"));
+  });
+
+  test("reads sheets", () => {
+    const workbook = new Workbook(
+      exceljs({
+        Sheet1: [
+          ["one", "two", "three"],
+          [1, 2, 3]
+        ]
+      })
+    );
+    assert.deepEqual(
+      workbook.sheet(0),
+      Object.assign(
+        [
+          {A: "one", B: "two", C: "three"},
+          {A: 1, B: 2, C: 3}
+        ],
+        {columns: [..."#ABC"]}
+      )
+    );
+    assert.deepEqual(
+      workbook.sheet("Sheet1"),
+      Object.assign(
+        [
+          {A: "one", B: "two", C: "three"},
+          {A: 1, B: 2, C: 3}
+        ],
+        {columns: [..."#ABC"]}
+      )
+    );
+    assert.strictEqual(workbook.sheet(0)[0]["#"], 1);
+    assert.strictEqual(workbook.sheet(0)[1]["#"], 2);
+  });
+
+  test("reads sheets with primitive types", () => {
+    assert.deepEqual(
+      new Workbook(
+        exceljs({
+          Sheet1: [
+            [],
+            [null, undefined],
+            ["hello", "", "0", "1"],
+            [1, 1.2],
+            [true, false],
+            [new Date(Date.UTC(2020, 0, 1)), {}]
+          ]
+        })
+      ).sheet(0),
+      Object.assign(
+        [
+          {},
+          {},
+          {A: "hello", B: "", C: "0", D: "1"},
+          {A: 1, B: 1.2},
+          {A: true, B: false},
+          {A: new Date(Date.UTC(2020, 0, 1))} // unknown shapes drop
+        ],
+        {columns: [..."#ABCD"]}
+      )
+    );
+  });
+
+  test("reads rich text and hyperlinks", () => {
+    assert.deepEqual(
+      new Workbook(
+        exceljs({
+          Sheet1: [
+            [
+              {richText: [{text: "two"}, {text: "three"}]}, // A
+              {text: "plain text"}, // B
+              {text: "https://example.com", hyperlink: "https://example.com"}, // C
+              {
+                text: {richText: [{text: "https://example.com"}]},
+                hyperlink: "https://example.com"
+              }, // D
+              {text: `link&</a>"'?`, hyperlink: 'https://example.com?q="'}, // E
+              {
+                text: {richText: [{text: "first"}, {text: "second"}]},
+                hyperlink: "https://example.com"
+              } // F
+            ]
+          ]
+        })
+      ).sheet(0),
+      Object.assign(
+        [
+          {
+            A: "twothree",
+            B: "plain text",
+            C: "https://example.com",
+            D: "https://example.com",
+            E: `https://example.com?q=" link&</a>"'?`,
+            F: "https://example.com firstsecond"
+          }
+        ],
+        {columns: [..."#ABCDEF"]}
+      )
+    );
+  });
+
+  test("reads formulas", () => {
+    assert.deepEqual(
+      new Workbook(
+        exceljs({
+          Sheet1: [
+            [
+              {formula: "=B2*5", result: 10},
+              {sharedFormula: "=B2*6", result: 12},
+              {sharedFormula: "=Z2*6", result: {error: "#REF!"}}
+            ]
+          ]
+        })
+      ).sheet(0),
+      Object.assign([{A: 10, B: 12, C: NaN}], {
+        columns: [..."#ABC"]
+      })
+    );
+  });
+
+  test("reads sheets with headers", () => {
+    const workbook = new Workbook(
+      exceljs({
+        Sheet1: [
+          [null, "one", "one", "two", "A", "0"],
+          [1, null, 3, 4, 5, "zero"],
+          [6, 7, 8, 9, 10]
+        ]
+      })
+    );
+    assert.deepEqual(
+      workbook.sheet(0, {headers: true}),
+      Object.assign(
+        [
+          {A: 1, one_: 3, two: 4, A_: 5, 0: "zero"},
+          {A: 6, one: 7, one_: 8, two: 9, A_: 10}
+        ],
+        {columns: ["#", "A", "one", "one_", "two", "A_", "0"]}
+      )
+    );
+  });
+
+  test("throws on invalid ranges", () => {
+    const workbook = new Workbook(exceljs({Sheet1: []}));
+    const malformed = /Malformed range specifier/;
+    assert.throws(() => workbook.sheet(0, {range: 0 as unknown as string}), malformed);
+    assert.throws(() => workbook.sheet(0, {range: ""}), malformed);
+    assert.throws(() => workbook.sheet(0, {range: "-:"}), malformed);
+    assert.throws(() => workbook.sheet(0, {range: " :"}), malformed);
+    assert.throws(() => workbook.sheet(0, {range: "a1:"}), malformed); // lowercase
+    assert.throws(() => workbook.sheet(0, {range: "1A:"}), malformed);
+  });
+
+  test("reads sheet ranges", () => {
+    const workbook = new Workbook(
+      exceljs({
+        Sheet1: [
+          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+          [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+          [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+          [30, 31, 32, 33, 34, 35, 36, 37, 38, 39]
+        ]
+      })
+    );
+
+    // undefined / ":"
+    const entireSheet = Object.assign(
+      [
+        {A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9},
+        {A: 10, B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
+        {A: 20, B: 21, C: 22, D: 23, E: 24, F: 25, G: 26, H: 27, I: 28, J: 29},
+        {A: 30, B: 31, C: 32, D: 33, E: 34, F: 35, G: 36, H: 37, I: 38, J: 39}
+      ],
+      {columns: [..."#ABCDEFGHIJ"]}
+    );
+    assert.deepEqual(workbook.sheet(0), entireSheet);
+    assert.deepEqual(workbook.sheet(0, {range: ":"}), entireSheet);
+
+    // "B2:C3"
+    assert.deepEqual(
+      workbook.sheet(0, {range: "B2:C3"}),
+      Object.assign(
+        [
+          {B: 11, C: 12},
+          {B: 21, C: 22}
+        ],
+        {columns: [..."#BC"]}
+      )
+    );
+
+    // ":C3"
+    assert.deepEqual(
+      workbook.sheet(0, {range: ":C3"}),
+      Object.assign(
+        [
+          {A: 0, B: 1, C: 2},
+          {A: 10, B: 11, C: 12},
+          {A: 20, B: 21, C: 22}
+        ],
+        {columns: [..."#ABC"]}
+      )
+    );
+
+    // "B2:"
+    assert.deepEqual(
+      workbook.sheet(0, {range: "B2:"}),
+      Object.assign(
+        [
+          {B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
+          {B: 21, C: 22, D: 23, E: 24, F: 25, G: 26, H: 27, I: 28, J: 29},
+          {B: 31, C: 32, D: 33, E: 34, F: 35, G: 36, H: 37, I: 38, J: 39}
+        ],
+        {columns: [..."#BCDEFGHIJ"]}
+      )
+    );
+
+    // "H:"
+    assert.deepEqual(
+      workbook.sheet(0, {range: "H:"}),
+      Object.assign(
+        [
+          {H: 7, I: 8, J: 9},
+          {H: 17, I: 18, J: 19},
+          {H: 27, I: 28, J: 29},
+          {H: 37, I: 38, J: 39}
+        ],
+        {columns: ["#", "H", "I", "J"]}
+      )
+    );
+
+    // ":C"
+    assert.deepEqual(
+      workbook.sheet(0, {range: ":C"}),
+      Object.assign(
+        [
+          {A: 0, B: 1, C: 2},
+          {A: 10, B: 11, C: 12},
+          {A: 20, B: 21, C: 22},
+          {A: 30, B: 31, C: 32}
+        ],
+        {columns: ["#", "A", "B", "C"]}
+      )
+    );
+
+    // ":Z"
+    assert.deepEqual(
+      workbook.sheet(0, {range: ":Z"}),
+      Object.assign(entireSheet.slice(), {
+        columns: [..."#ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
+      })
+    );
+
+    // "2:"
+    assert.deepEqual(
+      workbook.sheet(0, {range: "2:"}),
+      Object.assign(entireSheet.slice(1), {columns: entireSheet.columns})
+    );
+
+    // ":2"
+    assert.deepEqual(
+      workbook.sheet(0, {range: ":2"}),
+      Object.assign(entireSheet.slice(0, 2), {columns: entireSheet.columns})
+    );
+  });
+
+  test("derives column names such as A AA AAA…", () => {
+    const l0 = 26 * 26 * 23;
+    const workbook = new Workbook(
+      exceljs({
+        Sheet1: [Array.from({length: l0}).fill(1)]
+      })
+    );
+    assert.deepStrictEqual(
+      workbook.sheet(0).columns.filter((d: string) => d.match(/^A+$/)),
+      ["A", "AA", "AAA"]
+    );
+  });
+
+  test("headers protects __proto__ of row objects", () => {
+    const workbook = new Workbook(exceljs({Sheet1: [["__proto__"], [{a: 1}]]}));
+    assert.notStrictEqual(workbook.sheet(0, {headers: true})[0].a, 1);
+  });
+});

--- a/src/runtime/stdlib/xlsx.test.ts
+++ b/src/runtime/stdlib/xlsx.test.ts
@@ -1,21 +1,27 @@
 import ExcelJS from "exceljs";
-import {assert, describe, expect, test, vi} from "vitest";
+import {describe, expect, test, vi} from "vitest";
 import {Workbook} from "./xlsx.js";
 
 // Route exceljs to the version from devDependencies
 vi.mock("https://cdn.jsdelivr.net/npm/exceljs/+esm", async () => import("exceljs"));
 
+type Row = Record<string, ExcelJS.CellValue>;
+
 declare module "vitest" {
   interface Matchers {
-    toBeSheet: (sheet: Record<string, ExcelJS.CellValue>[] & {columns: string[]}) => unknown;
+    toBeSheet: (sheet: Row[] & {columns: string[]}) => unknown;
   }
 }
 
 // Sheets are decorated with a `.columns` property
 expect.extend({
   toBeSheet(a, b) {
+    a = Object.assign(
+      Array.from(a, (row: Row) => ({"#": row["#"], ...row})),
+      {columns: a.columns}
+    );
     return {
-      pass: this.equals(a, b) && this.equals(Reflect.get(a, "columns"), Reflect.get(b, "columns")),
+      pass: this.equals(a, b),
       message: () => `expected sheet to${this.isNot ? " not" : ""} be`,
       actual: a,
       expected: b
@@ -35,12 +41,12 @@ function createWorkbook(sheets: Record<string, ExcelJS.CellValue[][]>) {
 describe("FileAttachment.xlsx", () => {
   test("reads sheet names", () => {
     const workbook = createWorkbook({Sheet1: []});
-    assert.deepStrictEqual(workbook.sheetNames, ["Sheet1"]);
+    expect(workbook.sheetNames).toStrictEqual(["Sheet1"]);
   });
 
   test("sheet(name) throws on unknown sheet name", () => {
     const workbook = createWorkbook({Sheet1: []});
-    assert.throws(() => workbook.sheet("bad"));
+    expect(() => workbook.sheet("bad")).toThrowError("Sheet not found");
   });
 
   test("reads sheets", () => {
@@ -53,8 +59,8 @@ describe("FileAttachment.xlsx", () => {
     expect(workbook.sheet(0)).toBeSheet(
       Object.assign(
         [
-          {A: "one", B: "two", C: "three"},
-          {A: 1, B: 2, C: 3}
+          {"#": 1, A: "one", B: "two", C: "three"},
+          {"#": 2, A: 1, B: 2, C: 3}
         ],
         {columns: [..."#ABC"]}
       )
@@ -62,14 +68,12 @@ describe("FileAttachment.xlsx", () => {
     expect(workbook.sheet("Sheet1")).toBeSheet(
       Object.assign(
         [
-          {A: "one", B: "two", C: "three"},
-          {A: 1, B: 2, C: 3}
+          {"#": 1, A: "one", B: "two", C: "three"},
+          {"#": 2, A: 1, B: 2, C: 3}
         ],
         {columns: [..."#ABC"]}
       )
     );
-    assert.strictEqual(workbook.sheet(0)[0]["#"], 1);
-    assert.strictEqual(workbook.sheet(0)[1]["#"], 2);
   });
 
   test("reads sheets with primitive types", () => {
@@ -86,12 +90,12 @@ describe("FileAttachment.xlsx", () => {
     expect(workbook.sheet(0)).toBeSheet(
       Object.assign(
         [
-          {},
-          {},
-          {A: "hello", B: "", C: "0", D: "1"},
-          {A: 1, B: 1.2},
-          {A: true, B: false},
-          {A: new Date(Date.UTC(2020, 0, 1))} // unknown shapes drop
+          {"#": 1},
+          {"#": 2},
+          {"#": 3, A: "hello", B: "", C: "0", D: "1"},
+          {"#": 4, A: 1, B: 1.2},
+          {"#": 5, A: true, B: false},
+          {"#": 6, A: new Date(Date.UTC(2020, 0, 1))} // unknown shapes drop
         ],
         {columns: [..."#ABCD"]}
       )
@@ -112,6 +116,7 @@ describe("FileAttachment.xlsx", () => {
       Object.assign(
         [
           {
+            "#": 1,
             A: "twothree",
             B: `https://example.com?q=" link&</a>"'?`,
             C: "https://example.com"
@@ -135,7 +140,7 @@ describe("FileAttachment.xlsx", () => {
       ]
     });
     expect(workbook.sheet(0)).toBeSheet(
-      Object.assign([{B: "https://example.com [object Object]"}], {columns: [..."#AB"]})
+      Object.assign([{"#": 1, B: "https://example.com [object Object]"}], {columns: [..."#AB"]})
     );
   });
 
@@ -150,7 +155,7 @@ describe("FileAttachment.xlsx", () => {
       ]
     });
     expect(workbook.sheet(0)).toBeSheet(
-      Object.assign([{A: 10, B: 12, C: NaN}], {
+      Object.assign([{"#": 1, A: 10, B: 12, C: NaN}], {
         columns: [..."#ABC"]
       })
     );
@@ -167,8 +172,8 @@ describe("FileAttachment.xlsx", () => {
     expect(workbook.sheet(0, {headers: true})).toBeSheet(
       Object.assign(
         [
-          {A: 1, one_: 3, two: 4, A_: 5, 0: "zero"},
-          {A: 6, one: 7, one_: 8, two: 9, A_: 10}
+          {"#": 2, A: 1, one_: 3, two: 4, A_: 5, 0: "zero"},
+          {"#": 3, A: 6, one: 7, one_: 8, two: 9, A_: 10}
         ],
         {columns: ["#", "A", "one", "one_", "two", "A_", "0"]}
       )
@@ -178,12 +183,12 @@ describe("FileAttachment.xlsx", () => {
   test("throws on invalid ranges", () => {
     const workbook = createWorkbook({Sheet1: []});
     const malformed = /Malformed range specifier/;
-    assert.throws(() => workbook.sheet(0, {range: 0 as unknown as string}), malformed);
-    assert.throws(() => workbook.sheet(0, {range: ""}), malformed);
-    assert.throws(() => workbook.sheet(0, {range: "-:"}), malformed);
-    assert.throws(() => workbook.sheet(0, {range: " :"}), malformed);
-    assert.throws(() => workbook.sheet(0, {range: "a1:"}), malformed); // lowercase
-    assert.throws(() => workbook.sheet(0, {range: "1A:"}), malformed);
+    expect(() => workbook.sheet(0, {range: 0 as unknown as string})).toThrowError(malformed);
+    expect(() => workbook.sheet(0, {range: ""})).toThrowError(malformed);
+    expect(() => workbook.sheet(0, {range: "-:"})).toThrowError(malformed);
+    expect(() => workbook.sheet(0, {range: " :"})).toThrowError(malformed);
+    expect(() => workbook.sheet(0, {range: "a1:"})).toThrowError(malformed); // lowercase
+    expect(() => workbook.sheet(0, {range: "1A:"})).toThrowError(malformed);
   });
 
   test("reads sheet ranges", () => {
@@ -199,10 +204,10 @@ describe("FileAttachment.xlsx", () => {
     // undefined / ":"
     const entireSheet = Object.assign(
       [
-        {A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9},
-        {A: 10, B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
-        {A: 20, B: 21, C: 22, D: 23, E: 24, F: 25, G: 26, H: 27, I: 28, J: 29},
-        {A: 30, B: 31, C: 32, D: 33, E: 34, F: 35, G: 36, H: 37, I: 38, J: 39}
+        {"#": 1, A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7, I: 8, J: 9},
+        {"#": 2, A: 10, B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
+        {"#": 3, A: 20, B: 21, C: 22, D: 23, E: 24, F: 25, G: 26, H: 27, I: 28, J: 29},
+        {"#": 4, A: 30, B: 31, C: 32, D: 33, E: 34, F: 35, G: 36, H: 37, I: 38, J: 39}
       ],
       {columns: [..."#ABCDEFGHIJ"]}
     );
@@ -213,8 +218,8 @@ describe("FileAttachment.xlsx", () => {
     expect(workbook.sheet(0, {range: "B2:C3"})).toBeSheet(
       Object.assign(
         [
-          {B: 11, C: 12},
-          {B: 21, C: 22}
+          {"#": 2, B: 11, C: 12},
+          {"#": 3, B: 21, C: 22}
         ],
         {columns: [..."#BC"]}
       )
@@ -224,9 +229,9 @@ describe("FileAttachment.xlsx", () => {
     expect(workbook.sheet(0, {range: ":C3"})).toBeSheet(
       Object.assign(
         [
-          {A: 0, B: 1, C: 2},
-          {A: 10, B: 11, C: 12},
-          {A: 20, B: 21, C: 22}
+          {"#": 1, A: 0, B: 1, C: 2},
+          {"#": 2, A: 10, B: 11, C: 12},
+          {"#": 3, A: 20, B: 21, C: 22}
         ],
         {columns: [..."#ABC"]}
       )
@@ -236,9 +241,9 @@ describe("FileAttachment.xlsx", () => {
     expect(workbook.sheet(0, {range: "B2:"})).toBeSheet(
       Object.assign(
         [
-          {B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
-          {B: 21, C: 22, D: 23, E: 24, F: 25, G: 26, H: 27, I: 28, J: 29},
-          {B: 31, C: 32, D: 33, E: 34, F: 35, G: 36, H: 37, I: 38, J: 39}
+          {"#": 2, B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
+          {"#": 3, B: 21, C: 22, D: 23, E: 24, F: 25, G: 26, H: 27, I: 28, J: 29},
+          {"#": 4, B: 31, C: 32, D: 33, E: 34, F: 35, G: 36, H: 37, I: 38, J: 39}
         ],
         {columns: [..."#BCDEFGHIJ"]}
       )
@@ -248,10 +253,10 @@ describe("FileAttachment.xlsx", () => {
     expect(workbook.sheet(0, {range: "H:"})).toBeSheet(
       Object.assign(
         [
-          {H: 7, I: 8, J: 9},
-          {H: 17, I: 18, J: 19},
-          {H: 27, I: 28, J: 29},
-          {H: 37, I: 38, J: 39}
+          {"#": 1, H: 7, I: 8, J: 9},
+          {"#": 2, H: 17, I: 18, J: 19},
+          {"#": 3, H: 27, I: 28, J: 29},
+          {"#": 4, H: 37, I: 38, J: 39}
         ],
         {columns: ["#", "H", "I", "J"]}
       )
@@ -261,10 +266,10 @@ describe("FileAttachment.xlsx", () => {
     expect(workbook.sheet(0, {range: ":C"})).toBeSheet(
       Object.assign(
         [
-          {A: 0, B: 1, C: 2},
-          {A: 10, B: 11, C: 12},
-          {A: 20, B: 21, C: 22},
-          {A: 30, B: 31, C: 32}
+          {"#": 1, A: 0, B: 1, C: 2},
+          {"#": 2, A: 10, B: 11, C: 12},
+          {"#": 3, A: 20, B: 21, C: 22},
+          {"#": 4, A: 30, B: 31, C: 32}
         ],
         {columns: ["#", "A", "B", "C"]}
       )
@@ -291,16 +296,22 @@ describe("FileAttachment.xlsx", () => {
   test("derives column names such as A AA AAA…", () => {
     const l0 = 26 * 26 * 23;
     const workbook = createWorkbook({Sheet1: [Array.from<number>({length: l0}).fill(1)]});
-    assert.deepStrictEqual(
-      workbook.sheet(0).columns.filter((d: string) => d.match(/^A+$/)),
-      ["A", "AA", "AAA"]
-    );
+    expect(workbook.sheet(0).columns.filter((d: string) => d.match(/^A+$/))).toEqual([
+      "A",
+      "AA",
+      "AAA"
+    ]);
   });
 
   test("headers protects __proto__ of row objects", () => {
     const workbook = createWorkbook({
-      Sheet1: [["__proto__"], [{a: 1} as unknown as ExcelJS.CellValue]]
+      Sheet1: [
+        ["foo", "__proto__"],
+        [1, {a: 2} as unknown as ExcelJS.CellValue]
+      ]
     });
-    assert.notStrictEqual(workbook.sheet(0, {headers: true})[0].a, 1);
+    const [row] = workbook.sheet(0, {headers: true});
+    expect(row.foo).toBe(1);
+    expect(row.a).not.toBe(2);
   });
 });

--- a/src/runtime/stdlib/xlsx.test.ts
+++ b/src/runtime/stdlib/xlsx.test.ts
@@ -15,6 +15,14 @@ function exceljs(contents: Record<string, ExcelJS.CellValue[][]>): ExcelJS.Workb
   return workbook;
 }
 
+function sheetEquals(
+  actual: object[] & {columns: string[]},
+  expected: object[] & {columns: string[]}
+): void {
+  assert.deepEqual([...actual], [...expected]);
+  assert.deepStrictEqual(actual.columns, expected.columns);
+}
+
 describe("FileAttachment.xlsx", () => {
   test("reads sheet names", () => {
     const workbook = new Workbook(exceljs({Sheet1: []}));
@@ -35,7 +43,7 @@ describe("FileAttachment.xlsx", () => {
         ]
       })
     );
-    assert.deepEqual(
+    sheetEquals(
       workbook.sheet(0),
       Object.assign(
         [
@@ -45,7 +53,7 @@ describe("FileAttachment.xlsx", () => {
         {columns: [..."#ABC"]}
       )
     );
-    assert.deepEqual(
+    sheetEquals(
       workbook.sheet("Sheet1"),
       Object.assign(
         [
@@ -60,7 +68,7 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("reads sheets with primitive types", () => {
-    assert.deepEqual(
+    sheetEquals(
       new Workbook(
         exceljs({
           Sheet1: [
@@ -88,7 +96,7 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("reads rich text and hyperlinks", () => {
-    assert.deepEqual(
+    sheetEquals(
       new Workbook(
         exceljs({
           Sheet1: [
@@ -114,7 +122,7 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("fails on malformed hyperlinks", () => {
-    assert.deepEqual(
+    sheetEquals(
       new Workbook(
         exceljs({
           Sheet1: [
@@ -133,7 +141,7 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("reads formulas", () => {
-    assert.deepEqual(
+    sheetEquals(
       new Workbook(
         exceljs({
           Sheet1: [
@@ -161,7 +169,7 @@ describe("FileAttachment.xlsx", () => {
         ]
       })
     );
-    assert.deepEqual(
+    sheetEquals(
       workbook.sheet(0, {headers: true}),
       Object.assign(
         [
@@ -206,11 +214,11 @@ describe("FileAttachment.xlsx", () => {
       ],
       {columns: [..."#ABCDEFGHIJ"]}
     );
-    assert.deepEqual(workbook.sheet(0), entireSheet);
-    assert.deepEqual(workbook.sheet(0, {range: ":"}), entireSheet);
+    sheetEquals(workbook.sheet(0), entireSheet);
+    sheetEquals(workbook.sheet(0, {range: ":"}), entireSheet);
 
     // "B2:C3"
-    assert.deepEqual(
+    sheetEquals(
       workbook.sheet(0, {range: "B2:C3"}),
       Object.assign(
         [
@@ -222,7 +230,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // ":C3"
-    assert.deepEqual(
+    sheetEquals(
       workbook.sheet(0, {range: ":C3"}),
       Object.assign(
         [
@@ -235,7 +243,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // "B2:"
-    assert.deepEqual(
+    sheetEquals(
       workbook.sheet(0, {range: "B2:"}),
       Object.assign(
         [
@@ -248,7 +256,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // "H:"
-    assert.deepEqual(
+    sheetEquals(
       workbook.sheet(0, {range: "H:"}),
       Object.assign(
         [
@@ -262,7 +270,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // ":C"
-    assert.deepEqual(
+    sheetEquals(
       workbook.sheet(0, {range: ":C"}),
       Object.assign(
         [
@@ -276,7 +284,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // ":Z"
-    assert.deepEqual(
+    sheetEquals(
       workbook.sheet(0, {range: ":Z"}),
       Object.assign(entireSheet.slice(), {
         columns: [..."#ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
@@ -284,13 +292,13 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // "2:"
-    assert.deepEqual(
+    sheetEquals(
       workbook.sheet(0, {range: "2:"}),
       Object.assign(entireSheet.slice(1), {columns: entireSheet.columns})
     );
 
     // ":2"
-    assert.deepEqual(
+    sheetEquals(
       workbook.sheet(0, {range: ":2"}),
       Object.assign(entireSheet.slice(0, 2), {columns: entireSheet.columns})
     );

--- a/src/runtime/stdlib/xlsx.test.ts
+++ b/src/runtime/stdlib/xlsx.test.ts
@@ -1,50 +1,48 @@
 import ExcelJS from "exceljs";
-import {assert, describe, test, vi} from "vitest";
+import {assert, describe, expect, test, vi} from "vitest";
 
 // Route exceljs to the version from devDependencies
 vi.mock("https://cdn.jsdelivr.net/npm/exceljs/+esm", async () => await import("exceljs"));
 
 const {Workbook} = await import("./xlsx.js");
 
-function exceljs(contents: Record<string, ExcelJS.CellValue[][]>): ExcelJS.Workbook {
+function createWorkbook(sheets: Record<string, ExcelJS.CellValue[][]>) {
   const workbook = new ExcelJS.Workbook();
-  for (const [sheet, rows] of Object.entries(contents)) {
+  for (const [sheet, rows] of Object.entries(sheets)) {
     const ws = workbook.addWorksheet(sheet);
     for (const row of rows) ws.addRow(row);
   }
-  return workbook;
+  return new Workbook(workbook);
 }
 
-function sheetEquals(
-  actual: object[] & {columns: string[]},
-  expected: object[] & {columns: string[]}
-): void {
-  assert.deepEqual([...actual], [...expected]);
-  assert.deepStrictEqual(actual.columns, expected.columns);
-}
+// Sheets are decorated with a `.columns` property
+expect.addEqualityTesters([
+  function (a, b) {
+    return !Array.isArray(a) || !Array.isArray(b)
+      ? undefined // pass
+      : this.equals(a, b) && this.equals(Reflect.get(a, "columns"), Reflect.get(b, "columns")); // test all arrays
+  }
+]);
 
 describe("FileAttachment.xlsx", () => {
   test("reads sheet names", () => {
-    const workbook = new Workbook(exceljs({Sheet1: []}));
+    const workbook = createWorkbook({Sheet1: []});
     assert.deepStrictEqual(workbook.sheetNames, ["Sheet1"]);
   });
 
   test("sheet(name) throws on unknown sheet name", () => {
-    const workbook = new Workbook(exceljs({Sheet1: []}));
+    const workbook = createWorkbook({Sheet1: []});
     assert.throws(() => workbook.sheet("bad"));
   });
 
   test("reads sheets", () => {
-    const workbook = new Workbook(
-      exceljs({
-        Sheet1: [
-          ["one", "two", "three"],
-          [1, 2, 3]
-        ]
-      })
-    );
-    sheetEquals(
-      workbook.sheet(0),
+    const workbook = createWorkbook({
+      Sheet1: [
+        ["one", "two", "three"],
+        [1, 2, 3]
+      ]
+    });
+    expect(workbook.sheet(0)).toEqual(
       Object.assign(
         [
           {A: "one", B: "two", C: "three"},
@@ -53,8 +51,7 @@ describe("FileAttachment.xlsx", () => {
         {columns: [..."#ABC"]}
       )
     );
-    sheetEquals(
-      workbook.sheet("Sheet1"),
+    expect(workbook.sheet("Sheet1")).toEqual(
       Object.assign(
         [
           {A: "one", B: "two", C: "three"},
@@ -68,19 +65,17 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("reads sheets with primitive types", () => {
-    sheetEquals(
-      new Workbook(
-        exceljs({
-          Sheet1: [
-            [],
-            [null, undefined],
-            ["hello", "", "0", "1"],
-            [1, 1.2],
-            [true, false],
-            [new Date(Date.UTC(2020, 0, 1)), {} as unknown as ExcelJS.CellValue]
-          ]
-        })
-      ).sheet(0),
+    const workbook = createWorkbook({
+      Sheet1: [
+        [],
+        [null, undefined],
+        ["hello", "", "0", "1"],
+        [1, 1.2],
+        [true, false],
+        [new Date(Date.UTC(2020, 0, 1)), {} as unknown as ExcelJS.CellValue]
+      ]
+    });
+    expect(workbook.sheet(0)).toEqual(
       Object.assign(
         [
           {},
@@ -96,18 +91,16 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("reads rich text and hyperlinks", () => {
-    sheetEquals(
-      new Workbook(
-        exceljs({
-          Sheet1: [
-            [
-              {richText: [{text: "two"}, {text: "three"}]}, // A
-              {text: `link&</a>"'?`, hyperlink: 'https://example.com?q="'}, // B
-              {text: "https://example.com", hyperlink: "https://example.com"} // C, text===hyperlink
-            ]
-          ]
-        })
-      ).sheet(0),
+    const workbook = createWorkbook({
+      Sheet1: [
+        [
+          {richText: [{text: "two"}, {text: "three"}]}, // A
+          {text: `link&</a>"'?`, hyperlink: 'https://example.com?q="'}, // B
+          {text: "https://example.com", hyperlink: "https://example.com"} // C, text===hyperlink
+        ]
+      ]
+    });
+    expect(workbook.sheet(0)).toEqual(
       Object.assign(
         [
           {
@@ -122,37 +115,33 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("fails on malformed hyperlinks", () => {
-    sheetEquals(
-      new Workbook(
-        exceljs({
-          Sheet1: [
-            [
-              {text: "plain text"} as unknown as ExcelJS.CellValue, // A (drop)
-              {
-                text: {richText: [{text: "https://example.com"}]},
-                hyperlink: "https://example.com"
-              } as unknown as ExcelJS.CellValue // B
-            ]
-          ]
-        })
-      ).sheet(0),
+    const workbook = createWorkbook({
+      Sheet1: [
+        [
+          {text: "plain text"} as unknown as ExcelJS.CellValue, // A (drop)
+          {
+            text: {richText: [{text: "https://example.com"}]},
+            hyperlink: "https://example.com"
+          } as unknown as ExcelJS.CellValue // B
+        ]
+      ]
+    });
+    expect(workbook.sheet(0)).toEqual(
       Object.assign([{B: "https://example.com [object Object]"}], {columns: [..."#AB"]})
     );
   });
 
   test("reads formulas", () => {
-    sheetEquals(
-      new Workbook(
-        exceljs({
-          Sheet1: [
-            [
-              {formula: "=B2*5", result: 10},
-              {sharedFormula: "=B2*6", result: 12},
-              {sharedFormula: "=Z2*6", result: {error: "#REF!"}}
-            ]
-          ]
-        })
-      ).sheet(0),
+    const workbook = createWorkbook({
+      Sheet1: [
+        [
+          {formula: "=B2*5", result: 10},
+          {sharedFormula: "=B2*6", result: 12},
+          {sharedFormula: "=Z2*6", result: {error: "#REF!"}}
+        ]
+      ]
+    });
+    expect(workbook.sheet(0)).toEqual(
       Object.assign([{A: 10, B: 12, C: NaN}], {
         columns: [..."#ABC"]
       })
@@ -160,17 +149,14 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("reads sheets with headers", () => {
-    const workbook = new Workbook(
-      exceljs({
-        Sheet1: [
-          [null, "one", "one", "two", "A", "0"],
-          [1, null, 3, 4, 5, "zero"],
-          [6, 7, 8, 9, 10]
-        ]
-      })
-    );
-    sheetEquals(
-      workbook.sheet(0, {headers: true}),
+    const workbook = createWorkbook({
+      Sheet1: [
+        [null, "one", "one", "two", "A", "0"],
+        [1, null, 3, 4, 5, "zero"],
+        [6, 7, 8, 9, 10]
+      ]
+    });
+    expect(workbook.sheet(0, {headers: true})).toEqual(
       Object.assign(
         [
           {A: 1, one_: 3, two: 4, A_: 5, 0: "zero"},
@@ -182,7 +168,7 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("throws on invalid ranges", () => {
-    const workbook = new Workbook(exceljs({Sheet1: []}));
+    const workbook = createWorkbook({Sheet1: []});
     const malformed = /Malformed range specifier/;
     assert.throws(() => workbook.sheet(0, {range: 0 as unknown as string}), malformed);
     assert.throws(() => workbook.sheet(0, {range: ""}), malformed);
@@ -193,16 +179,14 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("reads sheet ranges", () => {
-    const workbook = new Workbook(
-      exceljs({
-        Sheet1: [
-          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-          [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
-          [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
-          [30, 31, 32, 33, 34, 35, 36, 37, 38, 39]
-        ]
-      })
-    );
+    const workbook = createWorkbook({
+      Sheet1: [
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+        [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+        [30, 31, 32, 33, 34, 35, 36, 37, 38, 39]
+      ]
+    });
 
     // undefined / ":"
     const entireSheet = Object.assign(
@@ -214,12 +198,11 @@ describe("FileAttachment.xlsx", () => {
       ],
       {columns: [..."#ABCDEFGHIJ"]}
     );
-    sheetEquals(workbook.sheet(0), entireSheet);
-    sheetEquals(workbook.sheet(0, {range: ":"}), entireSheet);
+    expect(workbook.sheet(0)).toEqual(entireSheet);
+    expect(workbook.sheet(0, {range: ":"})).toEqual(entireSheet);
 
     // "B2:C3"
-    sheetEquals(
-      workbook.sheet(0, {range: "B2:C3"}),
+    expect(workbook.sheet(0, {range: "B2:C3"})).toEqual(
       Object.assign(
         [
           {B: 11, C: 12},
@@ -230,8 +213,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // ":C3"
-    sheetEquals(
-      workbook.sheet(0, {range: ":C3"}),
+    expect(workbook.sheet(0, {range: ":C3"})).toEqual(
       Object.assign(
         [
           {A: 0, B: 1, C: 2},
@@ -243,8 +225,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // "B2:"
-    sheetEquals(
-      workbook.sheet(0, {range: "B2:"}),
+    expect(workbook.sheet(0, {range: "B2:"})).toEqual(
       Object.assign(
         [
           {B: 11, C: 12, D: 13, E: 14, F: 15, G: 16, H: 17, I: 18, J: 19},
@@ -256,8 +237,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // "H:"
-    sheetEquals(
-      workbook.sheet(0, {range: "H:"}),
+    expect(workbook.sheet(0, {range: "H:"})).toEqual(
       Object.assign(
         [
           {H: 7, I: 8, J: 9},
@@ -270,8 +250,7 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // ":C"
-    sheetEquals(
-      workbook.sheet(0, {range: ":C"}),
+    expect(workbook.sheet(0, {range: ":C"})).toEqual(
       Object.assign(
         [
           {A: 0, B: 1, C: 2},
@@ -284,29 +263,26 @@ describe("FileAttachment.xlsx", () => {
     );
 
     // ":Z"
-    sheetEquals(
-      workbook.sheet(0, {range: ":Z"}),
+    expect(workbook.sheet(0, {range: ":Z"})).toEqual(
       Object.assign(entireSheet.slice(), {
         columns: [..."#ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
       })
     );
 
     // "2:"
-    sheetEquals(
-      workbook.sheet(0, {range: "2:"}),
+    expect(workbook.sheet(0, {range: "2:"})).toEqual(
       Object.assign(entireSheet.slice(1), {columns: entireSheet.columns})
     );
 
     // ":2"
-    sheetEquals(
-      workbook.sheet(0, {range: ":2"}),
+    expect(workbook.sheet(0, {range: ":2"})).toEqual(
       Object.assign(entireSheet.slice(0, 2), {columns: entireSheet.columns})
     );
   });
 
   test("derives column names such as A AA AAA…", () => {
     const l0 = 26 * 26 * 23;
-    const workbook = new Workbook(exceljs({Sheet1: [Array.from<number>({length: l0}).fill(1)]}));
+    const workbook = createWorkbook({Sheet1: [Array.from<number>({length: l0}).fill(1)]});
     assert.deepStrictEqual(
       workbook.sheet(0).columns.filter((d: string) => d.match(/^A+$/)),
       ["A", "AA", "AAA"]
@@ -314,9 +290,9 @@ describe("FileAttachment.xlsx", () => {
   });
 
   test("headers protects __proto__ of row objects", () => {
-    const workbook = new Workbook(
-      exceljs({Sheet1: [["__proto__"], [{a: 1} as unknown as ExcelJS.CellValue]]})
-    );
+    const workbook = createWorkbook({
+      Sheet1: [["__proto__"], [{a: 1} as unknown as ExcelJS.CellValue]]
+    });
     assert.notStrictEqual(workbook.sheet(0, {headers: true})[0].a, 1);
   });
 });

--- a/src/runtime/stdlib/xlsx.test.ts
+++ b/src/runtime/stdlib/xlsx.test.ts
@@ -127,20 +127,17 @@ describe("FileAttachment.xlsx", () => {
     );
   });
 
-  test("fails on malformed hyperlinks", () => {
+  test("handles empty hyperlinks", () => {
     const workbook = createWorkbook({
       Sheet1: [
         [
-          {text: "plain text"} as unknown as ExcelJS.CellValue, // A (drop)
-          {
-            text: {richText: [{text: "https://example.com"}]},
-            hyperlink: "https://example.com"
-          } as unknown as ExcelJS.CellValue // B
+          {text: "", hyperlink: ""},
+          {text: "text", hyperlink: ""}
         ]
       ]
     });
     expect(workbook.sheet(0)).toBeSheet(
-      Object.assign([{"#": 1, B: "https://example.com [object Object]"}], {columns: [..."#AB"]})
+      Object.assign([{"#": 1, A: "", B: "text"}], {columns: [..."#AB"]})
     );
   });
 
@@ -307,11 +304,12 @@ describe("FileAttachment.xlsx", () => {
     const workbook = createWorkbook({
       Sheet1: [
         ["foo", "__proto__"],
-        [1, {a: 2} as unknown as ExcelJS.CellValue]
+        [1, new Date("2024-01-01")]
       ]
     });
     const [row] = workbook.sheet(0, {headers: true});
     expect(row.foo).toBe(1);
-    expect(row.a).not.toBe(2);
+    expect(row.__proto__).toStrictEqual(new Date("2024-01-01"));
+    expect(row.getTime).toBe(undefined);
   });
 });


### PR DESCRIPTION
for #145

The tests were initially ported from https://github.com/observablehq/stdlib/blob/main/test/xlsx-test.js

Two of them had different results with the new code:

* a `{text: "plain text"}` object with no `hyperlink` property (used to return "plain text", now drops the value)
* a `RichText` object with an `hyperlink` property (the RichText was parsed, now it's not)

However, they covered cases that are invalid `ExcelJS.CellValue`. Hopefully these do not exist in the wild, otherwise we have now dropped support for them.

For now, I'm testing what they actually return (`undefined`, and `"link [object Object]"`), but maybe we want to catch this case instead?

I also upgraded the tests to validate the `columns` property.