### PR TITLE
/+esm for .js require, too

### DIFF
--- a/src/runtime/stdlib/require.ts
+++ b/src/runtime/stdlib/require.ts
@@ -33,7 +33,7 @@ function resolve(_specifier: unknown): string {
   const specifier = String(_specifier);
   if (isProtocol(specifier) || isLocal(specifier)) return specifier;
   const {name, range, path} = parseNpmSpecifier(specifier);
-  return `https://cdn.jsdelivr.net/npm/${name}${range}${path + (isFile(path) || isDirectory(path) ? "" : "/+esm")}`;
+  return `https://cdn.jsdelivr.net/npm/${name}${range}${path + ((isFile(path) && !isJavaScript(path)) || isDirectory(path) ? "" : "/+esm")}`;
 }
 
 /** Promote exclusive default export to module. */
@@ -60,6 +60,11 @@ function isLocal(specifier: string): boolean {
 }
 
 /** Returns true for e.g. foo/bar.js */
+function isJavaScript(specifier: string): boolean {
+  return /(\.js)$/i.test(specifier);
+}
+
+/** Returns true for e.g. foo/bar.txt */
 function isFile(specifier: string): boolean {
   return /(\.\w*)$/.test(specifier);
 }


### PR DESCRIPTION
Should solve a case as seen on https://observablehq.com/@mbostock/the-wealth-health-of-nations:

```js
d3 = require("d3@6.7.0/dist/d3.min.js")
```

This becomes:

```js
d3 = import("https://cdn.jsdelivr.net/npm/d3@6.7.0/dist/d3.min.js/+esm")
```