### PR TITLE
 Remove viewof$ from SQL cells

### DIFF
--- a/docs/ex/plot/flight-delays.html
+++ b/docs/ex/plot/flight-delays.html
@@ -55,6 +55,7 @@
       marks: [
         Plot.areaY(quantiles, {
           x: "hour",
+          sort: "hour",
           y1: "avg_delay",
           y2: "p10_delay",
           fillOpacity: 0.1,
@@ -62,6 +63,7 @@
         }),
         Plot.areaY(quantiles, {
           x: "hour",
+          sort: "hour",
           y1: "avg_delay",
           y2: "p90_delay",
           fillOpacity: 0.2,
@@ -69,17 +71,20 @@
         }),
         Plot.lineY(quantiles, {
           x: "hour",
+          sort: "hour",
           y: "avg_delay",
           curve: "monotone-x"
         }),
         Plot.lineY(quantiles, {
           x: "hour",
+          sort: "hour",
           y: "p10_delay",
           strokeDasharray: "2",
           curve: "monotone-x"
         }),
         Plot.lineY(quantiles, {
           x: "hour",
+          sort: "hour",
           y: "p90_delay",
           strokeDasharray: "2",
           curve: "monotone-x"

--- a/src/javascript/__snapshots__/transpile.test.ts.snap
+++ b/src/javascript/__snapshots__/transpile.test.ts.snap
@@ -277,7 +277,7 @@ exports[`transpiles empty cells 1`] = `
 exports[`transpiles empty cells 2`] = `
 {
   "autodisplay": false,
-  "autoview": false,
+  "autovalue": false,
   "body": "() => {
 
 }",
@@ -293,7 +293,7 @@ exports[`transpiles empty cells 2`] = `
 exports[`transpiles empty cells 3`] = `
 {
   "autodisplay": false,
-  "autoview": false,
+  "autovalue": false,
   "body": "() => {
 
 }",
@@ -309,7 +309,7 @@ exports[`transpiles empty cells 3`] = `
 exports[`transpiles empty cells 4`] = `
 {
   "autodisplay": false,
-  "autoview": false,
+  "autovalue": false,
   "body": "() => {
 
 }",
@@ -325,7 +325,7 @@ exports[`transpiles empty cells 4`] = `
 exports[`transpiles empty cells 5`] = `
 {
   "autodisplay": false,
-  "autoview": false,
+  "autovalue": false,
   "body": "() => {
 
 }",
@@ -392,7 +392,7 @@ return (
 exports[`transpiles node cells 1`] = `
 {
   "autodisplay": true,
-  "autoview": false,
+  "autovalue": false,
   "body": "(Interpreter) => {
 return (
 Interpreter("node", {id: -1, format: "buffer"}).run(\`process.stdout.write(\\\`Node $\\{process.version}\\\`);\`).then((file) => file.arrayBuffer())
@@ -412,7 +412,7 @@ Interpreter("node", {id: -1, format: "buffer"}).run(\`process.stdout.write(\\\`N
 exports[`transpiles node cells 2`] = `
 {
   "autodisplay": true,
-  "autoview": false,
+  "autovalue": false,
   "body": "(Interpreter) => {
 return (
 Interpreter("node", {id: -1, format: "buffer"}).run(\`process.stdout.write(\\\`Node \\\\$\\{process.version}\\\`);\`).then((file) => file.arrayBuffer())
@@ -432,7 +432,7 @@ Interpreter("node", {id: -1, format: "buffer"}).run(\`process.stdout.write(\\\`N
 exports[`transpiles node cells 3`] = `
 {
   "autodisplay": true,
-  "autoview": false,
+  "autovalue": false,
   "body": "(Interpreter) => {
 return (
 Interpreter("node", {id: -1, format: "buffer"}).run(\`process.stdout.write(\\\`Node \\\\\\\\$\\{process.version}\\\`);\`).then((file) => file.arrayBuffer())
@@ -452,7 +452,7 @@ Interpreter("node", {id: -1, format: "buffer"}).run(\`process.stdout.write(\\\`N
 exports[`transpiles node cells 4`] = `
 {
   "autodisplay": true,
-  "autoview": false,
+  "autovalue": false,
   "body": "(Interpreter) => {
 return (
 Interpreter("node", {id: -1, format: "buffer"}).run(\`process.stdout.write(\\\`Node $\\\\{process.version}\\\`);\`).then((file) => file.arrayBuffer())
@@ -472,7 +472,7 @@ Interpreter("node", {id: -1, format: "buffer"}).run(\`process.stdout.write(\\\`N
 exports[`transpiles node cells 5`] = `
 {
   "autodisplay": true,
-  "autoview": false,
+  "autovalue": false,
   "body": "(Interpreter) => {
 return (
 Interpreter("node", {id: -1, format: "buffer"}).run(\`process.stdout.write(\\\`Node \\\\$\\\\{process.version}\\\`);\`).then((file) => file.arrayBuffer())

--- a/src/javascript/template.ts
+++ b/src/javascript/template.ts
@@ -141,7 +141,9 @@ function getInterpreterPrefix(cell: Cell): string {
 
 function getSuffix(cell: Cell): string {
   return cell.mode === "sql" && !cell.hidden
-    ? ".then(Inputs.table)"
+    ? cell.output // selecting rows is only useful if the output names the selection
+      ? ".then(Inputs.table)"
+      : ".then((data) => Inputs.table(data, {select: false}))"
     : isInterpreter(cell.mode)
       ? getInterpreterSuffix(cell)
       : "";

--- a/src/javascript/transpile.test.ts
+++ b/src/javascript/transpile.test.ts
@@ -61,6 +61,29 @@ it("transpiles import.meta.resolve", () => {
   expect(transpile('import.meta.resolve("./test")', "js", {resolveLocalImports: false})).toMatchSnapshot();
 });
 
+it("gives a visible sql cell with an output the value of the displayed table, keeping the output name as-is", () => {
+  const {autovalue, autodisplay, output, body} = transpile({id: 1, mode: "sql", value: "SELECT 1", output: "result"});
+  expect(autodisplay).toBe(true);
+  expect(autovalue).toBe(true);
+  expect(output).toBe("result"); // not renamed to viewof$result
+  expect(body).toContain(".then(Inputs.table)"); // selectable; the output names the selection
+});
+
+it("does not set autovalue on a sql cell without an output, and disables row selection", () => {
+  const {autovalue, autodisplay, body} = transpile({id: 1, mode: "sql", value: "SELECT 1"});
+  expect(autodisplay).toBe(true);
+  expect(autovalue).toBe(false);
+  expect(body).toContain("Inputs.table(data, {select: false})"); // nothing reads the selection
+});
+
+it("does not set autovalue on a hidden sql cell, since it displays no table", () => {
+  const {autovalue, autodisplay, output, body} = transpile({id: 1, mode: "sql", value: "SELECT 1", output: "result", hidden: true});
+  expect(autodisplay).toBe(false);
+  expect(autovalue).toBeFalsy();
+  expect(output).toBe("result");
+  expect(body).not.toContain("Inputs.table");
+});
+
 it("transpiles node cells", () => {
   expect(transpile("process.stdout.write(`Node ${process.version}`);", "node")).toMatchSnapshot();
   expect(transpile("process.stdout.write(`Node \\${process.version}`);", "node")).toMatchSnapshot();

--- a/src/javascript/transpile.ts
+++ b/src/javascript/transpile.ts
@@ -22,6 +22,8 @@ export type TranspiledJavaScript = {
   autodisplay?: boolean;
   /** whether to implicitly derive a view; requires viewof output */
   autoview?: boolean;
+  /** whether the output names the value of the displayed view (e.g., sql cells) */
+  autovalue?: boolean;
   /** whether to implicitly derive a mutable; requires mutable output */
   automutable?: boolean;
   /** the names of any referenced files */
@@ -73,8 +75,7 @@ export function transpile(
   if (cell.hidden) transpiled.autodisplay = false;
   else if (mode !== "js" && mode !== "ts" && mode !== "ojs") {
     transpiled.autodisplay = !!input;
-    transpiled.autoview = mode === "sql" && transpiled.autodisplay && !!transpiled.output;
-    if (transpiled.autoview) transpiled.output = `viewof$${transpiled.output}`;
+    transpiled.autovalue = mode === "sql" && transpiled.autodisplay && !!transpiled.output;
   }
   return transpiled;
 }

--- a/src/runtime/define.test.ts
+++ b/src/runtime/define.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import {Runtime} from "@observablehq/runtime";
+import type {Module} from "@observablehq/runtime";
+import {expect, it} from "vitest";
+import type {DefineState} from "./define.js";
+import {define} from "./define.js";
+import {library} from "./stdlib/index.js";
+
+function testModule(): Module {
+  return new Runtime(library).module();
+}
+
+function testState(): DefineState {
+  return {root: document.createElement("div"), expanded: [], variables: []};
+}
+
+// A view: an element whose value property holds the cell’s logical value.
+function numberInput(value: number): HTMLInputElement {
+  const element = document.createElement("input");
+  element.type = "number";
+  element.value = String(value);
+  return element;
+}
+
+it("defines an ojs viewof cell as both the view element (viewof$x) and its value (x)", async () => {
+  const main = testModule();
+  define(main, testState(), {
+    id: 1,
+    body: () => numberInput(42),
+    output: "viewof$x",
+    autodisplay: true,
+    autoview: true
+  });
+  expect(await main.value("viewof$x")).toBeInstanceOf(HTMLInputElement);
+  expect(await main.value("x")).toBe(42);
+});
+
+it("defines a sql cell output (autovalue) as the value of its table view, without exposing the view", async () => {
+  const main = testModule();
+  define(main, testState(), {
+    id: 1,
+    body: () => numberInput(42), // stands in for the Inputs.table element
+    output: "result",
+    autodisplay: true,
+    autovalue: true
+  });
+  expect(await main.value("result")).toBe(42);
+  await expect(main.value("viewof$result")).rejects.toThrow(/not defined/);
+});

--- a/src/runtime/define.ts
+++ b/src/runtime/define.ts
@@ -24,6 +24,8 @@ export type Definition = {
   autodisplay?: boolean;
   /** whether this cell’s singular output is a view */
   autoview?: boolean;
+  /** whether this cell’s singular output names the value of the displayed view (e.g., sql cells) */
+  autovalue?: boolean;
   /** whether this cell’s singular output is a mutable */
   automutable?: boolean;
   /** an asset mapping to apply to any autodisplayed assets (e.g., images and videos) */
@@ -31,10 +33,9 @@ export type Definition = {
 };
 
 export function define(main: Module, state: DefineState, definition: Definition, observer = observe): void {
-  const {id, body, inputs = [], outputs = [], output, autodisplay, autoview, automutable} = definition;
+  const {id, body, inputs = [], outputs = [], output, autodisplay, autoview, autovalue, automutable} = definition;
   const variables = state.variables;
   const v = main.variable(observer(state, definition), {shadow: {}});
-  const vid = output ?? (outputs.length ? `cell ${id}` : null);
   state.autoclear = true;
   if (inputs.includes("display") || inputs.includes("view")) {
     let displayVersion = -1; // the variable._version of currently-displayed values
@@ -63,9 +64,13 @@ export function define(main: Module, state: DefineState, definition: Definition,
   } else if (!autodisplay) {
     clear(state);
   }
-  variables.push(v.define(vid, inputs, body));
+  // With autovalue, the displayed view (e.g., a sql cell’s table) is anonymous
+  // and the output names its value; with autoview, the output names the view.
+  variables.push(v.define(autovalue ? `cell ${id}` : output ?? (outputs.length ? `cell ${id}` : null), inputs, body)); // prettier-ignore
   if (output != null) {
-    if (autoview) {
+    if (autovalue) {
+      variables.push(main.define(output, [`cell ${id}`], input));
+    } else if (autoview) {
       const o = unprefix(output, "viewof$");
       variables.push(main.define(o, [output], input));
     } else if (automutable) {
@@ -80,7 +85,7 @@ export function define(main: Module, state: DefineState, definition: Definition,
     }
   } else {
     for (const o of outputs) {
-      variables.push(main.variable(true).define(o, [vid!], (exports) => exports[o]));
+      variables.push(main.variable(true).define(o, [`cell ${id}`], (exports) => exports[o]));
     }
   }
 }

--- a/src/vite/observable.ts
+++ b/src/vite/observable.ts
@@ -226,6 +226,7 @@ define(
     assets: ${assets.size > 0 ? "assets" : "undefined"},
     autodisplay: ${transpiled.autodisplay},
     autoview: ${transpiled.autoview},
+    autovalue: ${transpiled.autovalue},
     automutable: ${transpiled.automutable}
   }
 );`;


### PR DESCRIPTION
A SQL cell with an output attribute no longer defines a `viewof$xxx`. Instead, the displayed table is registered under the internal name `cell ${id}`.

For example, `<script type="application/sql" output="result">` now defines a single variable `result` holding the resultset (possibly filter by the user using the checkboxes); previously it defined the table element as `viewof$result` and derived `result` from it.

This means `transpiled.output` now matches the cell's declared output, and SQL cells no longer expose (or leak) the table as `viewof$result`.

Also, since the selection of table rows is only useful when an output reads it, SQL cells without an output now render their table with the `select: false` option (no checkbox column).

(While I was playing with the table I noticed that the chart would be broken if you selected rows in arbitrary order, so I fixed that too.)