### PR TITLE
adds a link to the flight-delays example in the gallery

### DIFF
--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -133,6 +133,10 @@
         <div class="preview-image" style="background-image: url(&quot;https://static.observableusercontent.com/thumbnail/1580acba5e90463cc8809b034a3d30a9c9c523f858b13c2a3f9dd328c18119fe.jpg&quot;);"></div>
         <div class="preview-title">Epicyclic gearing</div>
       </a>
+      <a href="./ex/plot/flight-delays">
+        <div class="preview-image" style="background-image: url(&quot;https://static.observableusercontent.com/thumbnail/a031ffe18b3b3b12f2e8c16d7a0a16fc9dcc01554301d154f9a84cc1d60c7293.jpg&quot;);"></div>
+        <div class="preview-title">Flight delays</div>
+      </a>
       <a href="./ex/d3/force-directed-graph">
         <div class="preview-image" style="background-image: url(&quot;https://static.observableusercontent.com/thumbnail/daca6197a1592e5582e904387074d40ce144606eb639222eb9306ce38ba32623.jpg&quot;);"></div>
         <div class="preview-title">Force-directed graph</div>


### PR DESCRIPTION
ref. https://github.com/observablehq/notebook-kit/pull/134

<img width="1628" height="890" alt="flight delays addendum" src="https://github.com/user-attachments/assets/1647d539-f272-4832-860e-23d93b639ee7" />
