### PR TITLE
more dynamic imports + tests

### DIFF
--- a/src/javascript/__snapshots__/transpile.test.ts.snap
+++ b/src/javascript/__snapshots__/transpile.test.ts.snap
@@ -279,7 +279,7 @@ exports[`transpiles Observable JavaScript dynamic imports 5`] = `
   "automutable": false,
   "autoview": false,
   "body": "function(){return(
-import("https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/controls/OrbitControls.js/+esm")
+import("https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/controls/OrbitControls.js")
 )}",
   "databases": Set {},
   "files": Set {},

--- a/src/javascript/__snapshots__/transpile.test.ts.snap
+++ b/src/javascript/__snapshots__/transpile.test.ts.snap
@@ -1,5 +1,85 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ignores non-bare Observable JavaScript dynamic imports 1`] = `
+{
+  "autodisplay": true,
+  "automutable": false,
+  "autoview": false,
+  "body": "function(){return(
+import("./local.js")
+)}",
+  "databases": Set {},
+  "files": Set {},
+  "inputs": [],
+  "output": undefined,
+  "secrets": Set {},
+}
+`;
+
+exports[`ignores non-bare Observable JavaScript dynamic imports 2`] = `
+{
+  "autodisplay": true,
+  "automutable": false,
+  "autoview": false,
+  "body": "function(){return(
+import("../sibling.js")
+)}",
+  "databases": Set {},
+  "files": Set {},
+  "inputs": [],
+  "output": undefined,
+  "secrets": Set {},
+}
+`;
+
+exports[`ignores non-bare Observable JavaScript dynamic imports 3`] = `
+{
+  "autodisplay": true,
+  "automutable": false,
+  "autoview": false,
+  "body": "function(){return(
+import("/abs.js")
+)}",
+  "databases": Set {},
+  "files": Set {},
+  "inputs": [],
+  "output": undefined,
+  "secrets": Set {},
+}
+`;
+
+exports[`ignores non-bare Observable JavaScript dynamic imports 4`] = `
+{
+  "autodisplay": true,
+  "automutable": false,
+  "autoview": false,
+  "body": "function(){return(
+import("https://cdn.skypack.dev/canvas-confetti")
+)}",
+  "databases": Set {},
+  "files": Set {},
+  "inputs": [],
+  "output": undefined,
+  "secrets": Set {},
+}
+`;
+
+exports[`ignores non-bare Observable JavaScript dynamic imports 5`] = `
+{
+  "autodisplay": true,
+  "automutable": false,
+  "autoview": false,
+  "body": "function(){return(
+import("npm:d3")
+)}",
+  "databases": Set {},
+  "files": Set {},
+  "inputs": [],
+  "output": undefined,
+  "secrets": Set {},
+}
+`;
+
 exports[`transpiles JavaScript expressions 1`] = `
 {
   "autodisplay": true,
@@ -125,6 +205,102 @@ await z;
   ],
   "output": undefined,
   "outputs": [],
+  "secrets": Set {},
+}
+`;
+
+exports[`transpiles Observable JavaScript dynamic imports 1`] = `
+{
+  "autodisplay": true,
+  "automutable": false,
+  "autoview": false,
+  "body": "function(){return(
+import("https://cdn.jsdelivr.net/npm/d3/+esm")
+)}",
+  "databases": Set {},
+  "files": Set {},
+  "inputs": [],
+  "output": undefined,
+  "secrets": Set {},
+}
+`;
+
+exports[`transpiles Observable JavaScript dynamic imports 2`] = `
+{
+  "autodisplay": true,
+  "automutable": false,
+  "autoview": false,
+  "body": "function(){return(
+import("https://cdn.jsdelivr.net/npm/d3@7/+esm")
+)}",
+  "databases": Set {},
+  "files": Set {},
+  "inputs": [],
+  "output": undefined,
+  "secrets": Set {},
+}
+`;
+
+exports[`transpiles Observable JavaScript dynamic imports 3`] = `
+{
+  "autodisplay": true,
+  "automutable": false,
+  "autoview": false,
+  "body": "function(){return(
+import("https://cdn.jsdelivr.net/npm/@observablehq/plot/+esm")
+)}",
+  "databases": Set {},
+  "files": Set {},
+  "inputs": [],
+  "output": undefined,
+  "secrets": Set {},
+}
+`;
+
+exports[`transpiles Observable JavaScript dynamic imports 4`] = `
+{
+  "autodisplay": true,
+  "automutable": false,
+  "autoview": false,
+  "body": "function(){return(
+import("https://cdn.jsdelivr.net/npm/lodash/fp/+esm")
+)}",
+  "databases": Set {},
+  "files": Set {},
+  "inputs": [],
+  "output": undefined,
+  "secrets": Set {},
+}
+`;
+
+exports[`transpiles Observable JavaScript dynamic imports 5`] = `
+{
+  "autodisplay": true,
+  "automutable": false,
+  "autoview": false,
+  "body": "function(){return(
+import("https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/controls/OrbitControls.js/+esm")
+)}",
+  "databases": Set {},
+  "files": Set {},
+  "inputs": [],
+  "output": undefined,
+  "secrets": Set {},
+}
+`;
+
+exports[`transpiles Observable JavaScript dynamic imports 6`] = `
+{
+  "autodisplay": true,
+  "automutable": false,
+  "autoview": false,
+  "body": "function(){return(
+import("https://cdn.jsdelivr.net/npm/leaflet/dist/leaflet.css")
+)}",
+  "databases": Set {},
+  "files": Set {},
+  "inputs": [],
+  "output": undefined,
   "secrets": Set {},
 }
 `;

--- a/src/javascript/__snapshots__/transpile.test.ts.snap
+++ b/src/javascript/__snapshots__/transpile.test.ts.snap
@@ -279,7 +279,7 @@ exports[`transpiles Observable JavaScript dynamic imports 5`] = `
   "automutable": false,
   "autoview": false,
   "body": "function(){return(
-import("https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/controls/OrbitControls.js")
+import("https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/controls/OrbitControls.js/+esm")
 )}",
   "databases": Set {},
   "files": Set {},

--- a/src/javascript/imports/npm.test.ts
+++ b/src/javascript/imports/npm.test.ts
@@ -28,19 +28,11 @@ test("adds /+esm as expected", () => {
   );
   assert.strictEqual(
     resolveNpmImport("npm:prettier/plugins/acorn.js"),
-    "https://cdn.jsdelivr.net/npm/prettier/plugins/acorn.js/+esm" // bundles JS module files
+    "https://cdn.jsdelivr.net/npm/prettier/plugins/acorn.js" // no /+esm because file extension
   );
   assert.strictEqual(
     resolveNpmImport("npm:prettier/plugins/acorn.js/+esm"),
     "https://cdn.jsdelivr.net/npm/prettier/plugins/acorn.js/+esm" // preserve existing /+esm
-  );
-  assert.strictEqual(
-    resolveNpmImport("npm:foo/bar.mjs"),
-    "https://cdn.jsdelivr.net/npm/foo/bar.mjs/+esm" // /+esm because JS module file
-  );
-  assert.strictEqual(
-    resolveNpmImport("npm:three@0.150.1/examples/jsm/controls/OrbitControls.js"),
-    "https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/controls/OrbitControls.js/+esm" // bundle so internal bare imports resolve
   );
   assert.strictEqual(
     resolveNpmImport("npm:leaflet/dist/leaflet.css"),

--- a/src/javascript/imports/npm.test.ts
+++ b/src/javascript/imports/npm.test.ts
@@ -28,7 +28,7 @@ test("adds /+esm as expected", () => {
   );
   assert.strictEqual(
     resolveNpmImport("npm:prettier/plugins/acorn.js"),
-    "https://cdn.jsdelivr.net/npm/prettier/plugins/acorn.js" // no /+esm because file extension
+    "https://cdn.jsdelivr.net/npm/prettier/plugins/acorn.js/+esm" // bundles JS module files
   );
   assert.strictEqual(
     resolveNpmImport("npm:prettier/plugins/acorn.js/+esm"),

--- a/src/javascript/imports/npm.test.ts
+++ b/src/javascript/imports/npm.test.ts
@@ -35,6 +35,22 @@ test("adds /+esm as expected", () => {
     "https://cdn.jsdelivr.net/npm/prettier/plugins/acorn.js/+esm" // preserve existing /+esm
   );
   assert.strictEqual(
+    resolveNpmImport("npm:foo/bar.mjs"),
+    "https://cdn.jsdelivr.net/npm/foo/bar.mjs/+esm" // /+esm because JS module file
+  );
+  assert.strictEqual(
+    resolveNpmImport("npm:three@0.150.1/examples/jsm/controls/OrbitControls.js"),
+    "https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/controls/OrbitControls.js/+esm" // bundle so internal bare imports resolve
+  );
+  assert.strictEqual(
+    resolveNpmImport("npm:leaflet/dist/leaflet.css"),
+    "https://cdn.jsdelivr.net/npm/leaflet/dist/leaflet.css" // no /+esm because non-JS file
+  );
+  assert.strictEqual(
+    resolveNpmImport("npm:foo/data.json"),
+    "https://cdn.jsdelivr.net/npm/foo/data.json" // no /+esm because non-JS file
+  );
+  assert.strictEqual(
     resolveNpmImport("npm:prettier/plugins/estree"),
     "https://cdn.jsdelivr.net/npm/prettier/plugins/estree/+esm"
   );

--- a/src/javascript/imports/npm.ts
+++ b/src/javascript/imports/npm.ts
@@ -24,15 +24,21 @@ function parseNpmSpecifier(specifier: string): NpmSpecifier {
 export function resolveNpmImport(specifier: string): string {
   if (!specifier.startsWith("npm:")) return specifier;
   const {name, range, path} = parseNpmSpecifier(specifier.slice(4));
-  return `https://cdn.jsdelivr.net/npm/${name}${
-    range || getDefaultRange(name)
-  }${
-    path
-      ? !/(\.\w+|\/|\/\+esm)$/.test(path) // if not file, directory, or /+esm
-        ? `${path}/+esm` // then append /+esm
-        : path // otherwise keep as-is
-      : getDefaultPath(name)
-  }`;
+  const base = `https://cdn.jsdelivr.net/npm/${name}${range || getDefaultRange(name)}`;
+  switch (true) {
+    case path === "": // bare package
+      return `${base}${getDefaultPath(name)}`;
+    case path.endsWith(".js"): // JS module file
+    case path.endsWith(".mjs"):
+    case path.endsWith(".cjs"):
+      return `${base}${path}/+esm`;
+    case path.endsWith("/"): // directory
+    case path.endsWith("/+esm"): // +esm
+    case path.slice(path.lastIndexOf("/")).includes("."): // file (.css, .wasm)
+      return `${base}${path}`;
+    default: // bare subpath
+      return `${base}${path}/+esm`;
+  }
 }
 
 function getDefaultRange(name: string): string {

--- a/src/javascript/imports/npm.ts
+++ b/src/javascript/imports/npm.ts
@@ -24,21 +24,15 @@ function parseNpmSpecifier(specifier: string): NpmSpecifier {
 export function resolveNpmImport(specifier: string): string {
   if (!specifier.startsWith("npm:")) return specifier;
   const {name, range, path} = parseNpmSpecifier(specifier.slice(4));
-  const base = `https://cdn.jsdelivr.net/npm/${name}${range || getDefaultRange(name)}`;
-  switch (true) {
-    case path === "": // bare package
-      return `${base}${getDefaultPath(name)}`;
-    case path.endsWith(".js"): // JS module file
-    case path.endsWith(".mjs"):
-    case path.endsWith(".cjs"):
-      return `${base}${path}/+esm`;
-    case path.endsWith("/"): // directory
-    case path.endsWith("/+esm"): // +esm
-    case path.slice(path.lastIndexOf("/")).includes("."): // file (.css, .wasm)
-      return `${base}${path}`;
-    default: // bare subpath
-      return `${base}${path}/+esm`;
-  }
+  return `https://cdn.jsdelivr.net/npm/${name}${
+    range || getDefaultRange(name)
+  }${
+    path
+      ? !/(\.\w+|\/|\/\+esm)$/.test(path) // if not file, directory, or /+esm
+        ? `${path}/+esm` // then append /+esm
+        : path // otherwise keep as-is
+      : getDefaultPath(name)
+  }`;
 }
 
 function getDefaultRange(name: string): string {

--- a/src/javascript/observable.ts
+++ b/src/javascript/observable.ts
@@ -95,16 +95,19 @@ function transformObservableImport(body: ImportDeclaration): void {
   ];
 }
 
-/** Rewrite a bare dynamic import such as import("d3") to a CDN URL, like
+/**
+ * Rewrite a bare dynamic import such as import("d3") to a CDN URL, like
  * import("https://cdn.jsdelivr.net/npm/d3/+esm"), using the same resolution as
- * static imports. Protocol (npm:, https:, …) and local imports are left alone. */
+ * static imports. Protocol (npm:, https:, …) and local imports are left alone.
+ */
 function rewriteDynamicImports(output: Sourcemap, body: Node): void {
   simple(body, {
     ImportExpression({source}) {
       if (!isStringLiteral(source)) return;
       const value = getStringLiteralValue(source);
       if (/^(\w+:|\.?\.?\/)/.test(value)) return;
-      output.replaceLeft(source.start, source.end, JSON.stringify(resolveNpmImport(`npm:${value}`)));
+      const resolution = resolveNpmImport(`npm:${value}`);
+      output.replaceLeft(source.start, source.end, JSON.stringify(resolution));
     }
   });
 }

--- a/src/javascript/observable.ts
+++ b/src/javascript/observable.ts
@@ -104,8 +104,9 @@ function rewriteDynamicImports(output: Sourcemap, body: Node): void {
   simple(body, {
     ImportExpression({source}) {
       if (!isStringLiteral(source)) return;
-      const value = getStringLiteralValue(source);
+      let value = getStringLiteralValue(source);
       if (/^(\w+:|\.?\.?\/)/.test(value)) return;
+      if (/\.(js|mjs|cjs)$/.test(value)) value += "/+esm";
       const resolution = resolveNpmImport(`npm:${value}`);
       output.replaceLeft(source.start, source.end, JSON.stringify(resolution));
     }

--- a/src/javascript/observable.ts
+++ b/src/javascript/observable.ts
@@ -4,6 +4,7 @@ import {parseCell} from "@observablehq/parser";
 import type {Identifier, ImportDeclaration, Node} from "acorn";
 import {rewriteFileExpressions} from "./files.js";
 import {flatMapImportSpecifiers, rewriteImportDeclarations} from "./imports.js";
+import {resolveNpmImport} from "./imports/npm.js";
 import {Sourcemap} from "./sourcemap.js";
 import {getStringLiteralValue, isStringLiteral} from "./strings.js";
 import type {TranspiledJavaScript, TranspileOptions} from "./transpile.js";
@@ -94,13 +95,16 @@ function transformObservableImport(body: ImportDeclaration): void {
   ];
 }
 
+/** Rewrite a bare dynamic import such as import("d3") to a CDN URL, like
+ * import("https://cdn.jsdelivr.net/npm/d3/+esm"), using the same resolution as
+ * static imports. Protocol (npm:, https:, …) and local imports are left alone. */
 function rewriteDynamicImports(output: Sourcemap, body: Node): void {
   simple(body, {
     ImportExpression({source}) {
-      if (isStringLiteral(source) && !/^(\w+:|\.?\.?\/)/.test(getStringLiteralValue(source))) {
-        output.insertRight(source.start + 1, "https://unpkg.com/");
-        output.insertLeft(source.end - 1, "?module");
-      }
+      if (!isStringLiteral(source)) return;
+      const value = getStringLiteralValue(source);
+      if (/^(\w+:|\.?\.?\/)/.test(value)) return;
+      output.replaceLeft(source.start, source.end, JSON.stringify(resolveNpmImport(`npm:${value}`)));
     }
   });
 }

--- a/src/javascript/transpile.test.ts
+++ b/src/javascript/transpile.test.ts
@@ -84,6 +84,23 @@ it("transpiles Observable JavaScript import-withs of views and mutables", () => 
   expect(transpile('import {color} with {foo, viewof bar, mutable baz as qux} from "2d6bf7be248d66f3"', "ojs")).toMatchSnapshot();
 });
 
+it("transpiles Observable JavaScript dynamic imports", () => {
+  expect(transpile('import("d3")', "ojs")).toMatchSnapshot();
+  expect(transpile('import("d3@7")', "ojs")).toMatchSnapshot();
+  expect(transpile('import("@observablehq/plot")', "ojs")).toMatchSnapshot();
+  expect(transpile('import("lodash/fp")', "ojs")).toMatchSnapshot();
+  expect(transpile('import("three@0.150.1/examples/jsm/controls/OrbitControls.js")', "ojs")).toMatchSnapshot();
+  expect(transpile('import("leaflet/dist/leaflet.css")', "ojs")).toMatchSnapshot();
+});
+
+it("ignores non-bare Observable JavaScript dynamic imports", () => {
+  expect(transpile('import("./local.js")', "ojs")).toMatchSnapshot();
+  expect(transpile('import("../sibling.js")', "ojs")).toMatchSnapshot();
+  expect(transpile('import("/abs.js")', "ojs")).toMatchSnapshot();
+  expect(transpile('import("https://cdn.skypack.dev/canvas-confetti")', "ojs")).toMatchSnapshot();
+  expect(transpile('import("npm:d3")', "ojs")).toMatchSnapshot();
+});
+
 it("transpiles import.meta.resolve", () => {
   expect(transpile('import.meta.resolve("npm:d3")', "js")).toMatchSnapshot();
   expect(transpile('import.meta.resolve("./test")', "js", {resolveLocalImports: true})).toMatchSnapshot();


### PR DESCRIPTION
Rewrote `resolveNpmImport` in a way that looks easier to read.

The only functional change is a bug fix where this import (which is mentioned in the unit tests):

```ojs
import("prettier/plugins/acorn.js")
```

currently returns an empty `Module`. We solve it by bundling `js` files (and `mjs`, `cjs`).

With that change, the module is working as expected:

<img width="370" height="135" alt="" src="https://github.com/user-attachments/assets/6779d933-8a71-474b-b7b7-e238f0badaa9" />


If you don't like my code style change, a minimal diff is:

```diff
-      ? !/(\.\w+|\/|\/\+esm)$/.test(path) // if not file, directory, or /+esm
+      ? !/(\/|\/\+esm|\.(?![mc]?js$)\w+)$/.test(path) // if not directory, /+esm, or non-JS file
```

(This also fixes `import("three@…/OrbitControls.js")`.)

Another good thing to test is this wasm module:

```ojs
{
    const {instance} = await import("@viz-js/viz");
    const viz = await instance();
    return svg`<svg>${viz.renderSVGElement("digraph { Hello -> Wasm -> Works }")}`;
}
```