### PR TITLE
Let DuckDBClient.of() ingest `@uwdata/flechette` tables

### DIFF
--- a/src/runtime/stdlib/duckdb.js
+++ b/src/runtime/stdlib/duckdb.js
@@ -335,7 +335,7 @@ async function insertFlechetteTable(database, name, table, options) {
   const {tableToIPC} = await import("https://cdn.jsdelivr.net/npm/@uwdata/flechette@2.5.0/+esm");
   const connection = await database.connect();
   try {
-    await connection.insertArrowFromIPCStream(tableToIPC(table), {
+    await connection.insertArrowFromIPCStream(tableToIPC(table, {format: "stream"}), {
       name,
       schema: "main",
       ...options

--- a/src/runtime/stdlib/duckdb.js
+++ b/src/runtime/stdlib/duckdb.js
@@ -221,6 +221,7 @@ Object.defineProperty(DuckDBClient.prototype, "dialect", {value: "duckdb"});
 async function insertSource(database, name, source) {
   source = await source;
   if (isFileAttachment(source)) return insertFile(database, name, source);
+  if (isFlechetteTable(source)) return insertFlechetteTable(database, name, source);
   if (isArrowTable(source)) return insertArrowTable(database, name, source);
   if (Array.isArray(source)) return insertArray(database, name, source);
   if (isArqueroTable(source)) return insertArqueroTable(database, name, source);
@@ -229,6 +230,7 @@ async function insertSource(database, name, source) {
     if ("data" in source) {
       // data + options
       const {data, ...options} = source;
+      if (isFlechetteTable(data)) return insertFlechetteTable(database, name, data, options);
       if (isArrowTable(data)) return insertArrowTable(database, name, data, options);
       return insertArray(database, name, data, options);
     }
@@ -329,6 +331,20 @@ async function insertArrowTable(database, name, table, options) {
   }
 }
 
+async function insertFlechetteTable(database, name, table, options) {
+  const {tableToIPC} = await import("https://cdn.jsdelivr.net/npm/@uwdata/flechette@2.5.0/+esm");
+  const connection = await database.connect();
+  try {
+    await connection.insertArrowFromIPCStream(tableToIPC(table), {
+      name,
+      schema: "main",
+      ...options
+    });
+  } finally {
+    await connection.close();
+  }
+}
+
 async function insertArqueroTable(database, name, source) {
   // TODO When we have stdlib versioning and can upgrade Arquero to version 5,
   // we can then call source.toArrow() directly, with insertArrowTable()
@@ -399,6 +415,17 @@ function isFileAttachment(value) {
 // Arquero tables have a `toArrowBuffer` function
 function isArqueroTable(value) {
   return value && typeof value.toArrowBuffer === "function";
+}
+
+// Flechette tables have a `toColumns` method
+function isFlechetteTable(value) {
+  return (
+    value &&
+    typeof value.toColumns === "function" &&
+    typeof value.getChild === "function" &&
+    value.schema &&
+    Array.isArray(value.schema.fields)
+  );
 }
 
 // Returns true if the value is an Apache Arrow table. This uses a “duck” test

--- a/src/runtime/stdlib/duckdb.js
+++ b/src/runtime/stdlib/duckdb.js
@@ -321,11 +321,16 @@ async function insertUntypedCSV(connection, file, name) {
 async function insertArrowTable(database, name, table, options) {
   const connection = await database.connect();
   try {
-    await connection.insertArrowTable(table, {
-      name,
-      schema: "main",
-      ...options
-    });
+    await connection.insertArrowTable(table, {name, schema: "main", ...options});
+  } finally {
+    await connection.close();
+  }
+}
+
+async function insertArrowIpc(database, name, buffer, options) {
+  const connection = await database.connect();
+  try {
+    await connection.insertArrowFromIPCStream(buffer, {name, schema: "main", ...options});
   } finally {
     await connection.close();
   }
@@ -333,24 +338,12 @@ async function insertArrowTable(database, name, table, options) {
 
 async function insertFlechetteTable(database, name, table, options) {
   const {tableToIPC} = await import("https://cdn.jsdelivr.net/npm/@uwdata/flechette@2.5.0/+esm");
-  const connection = await database.connect();
-  try {
-    await connection.insertArrowFromIPCStream(tableToIPC(table, {format: "stream"}), {
-      name,
-      schema: "main",
-      ...options
-    });
-  } finally {
-    await connection.close();
-  }
+  return await insertArrowIpc(database, name, tableToIPC(table, {format: "stream"}), options);
 }
 
 async function insertArqueroTable(database, name, source) {
-  // TODO When we have stdlib versioning and can upgrade Arquero to version 5,
-  // we can then call source.toArrow() directly, with insertArrowTable()
-  const arrow = await import("https://cdn.jsdelivr.net/npm/apache-arrow@17.0.0/+esm");
-  const table = arrow.tableFromIPC(source.toArrowBuffer());
-  return await insertArrowTable(database, name, table);
+  const buffer = typeof source.toArrowIPC === "function" ? source.toArrowIPC() : source.toArrowBuffer(); // prettier-ignore
+  return await insertArrowIpc(database, name, buffer);
 }
 
 async function insertArray(database, name, array, options) {
@@ -412,9 +405,11 @@ function isFileAttachment(value) {
   );
 }
 
-// Arquero tables have a `toArrowBuffer` function
+// Arquero tables have a `toArrowBuffer` (v5-) or `toArrowIPC` (v6+) function
 function isArqueroTable(value) {
-  return value && typeof value.toArrowBuffer === "function";
+  return (
+    value && (typeof value.toArrowBuffer === "function" || typeof value.toArrowIPC === "function")
+  );
 }
 
 // Flechette tables have a `toColumns` method


### PR DESCRIPTION
```js
const flechette = await import("npm:@uwdata/flechette");
const flights = flechette.tableFromIPC(
  await FileAttachment("data/flights-200k.arrow").arrayBuffer(),
  {useDate: true}
);
const db = await DuckDBClient.of({flights});
console.log(await db.sql`SHOW TABLES`); // [{name: "flights"}]
```

Note that `{useDate: true}` is optional, DuckDB doesn't care about the contents when it ingests a date column, because it uses the table schema.