### PR TITLE
Replace deprecated Vite alias customResolver with a pre resolveId hook

### DIFF
--- a/src/vite/config.ts
+++ b/src/vite/config.ts
@@ -1,7 +1,6 @@
 import {dirname, resolve} from "node:path";
 import {fileURLToPath} from "node:url";
 import type {UserConfig} from "vite";
-import {resolveNpmImport} from "../javascript/imports/npm.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -17,11 +16,6 @@ export function config(): UserConfig {
     },
     resolve: {
       alias: [
-        {
-          find: /^(npm:.*)$/,
-          replacement: "$1",
-          customResolver: (source) => ({id: resolveNpmImport(source), external: true})
-        },
         {
           find: /^jsr:(.*)$/,
           replacement: "https://esm.sh/jsr/$1"

--- a/src/vite/observable.test.ts
+++ b/src/vite/observable.test.ts
@@ -1,0 +1,14 @@
+import {assert, test} from "vitest";
+import type {Plugin} from "vite";
+import {observable, resolveNpmId} from "./observable.js";
+
+test("resolves npm imports from the pre Vite plugin", () => {
+  const plugin = observable() as Plugin;
+  assert.strictEqual(plugin.enforce, "pre");
+  assert.strictEqual(plugin.resolveId, resolveNpmId);
+  assert.deepStrictEqual(resolveNpmId("npm:d3"), {
+    id: "https://cdn.jsdelivr.net/npm/d3/+esm",
+    external: true
+  });
+  assert.strictEqual(resolveNpmId("./local.js"), null);
+});

--- a/src/vite/observable.ts
+++ b/src/vite/observable.ts
@@ -9,6 +9,7 @@ import {JSDOM} from "jsdom";
 import type {PluginOption, IndexHtmlTransformContext} from "vite";
 import {getQueryCachePath} from "../databases/index.js";
 import {getInterpreterCachePath, getInterpreterCommand} from "../interpreters/index.js";
+import {resolveNpmImport} from "../javascript/imports/npm.js";
 import {getInterpreterMethod, isInterpreter} from "../lib/interpreters.js";
 import type {Cell, Notebook} from "../lib/notebook.js";
 import {isDatabase} from "../lib/notebook.js";
@@ -57,6 +58,10 @@ export interface ObservableOptions {
   transformNotebook?: NotebookTransform;
 }
 
+export function resolveNpmId(source: string): {id: string; external: true} | null {
+  return source.startsWith("npm:") ? {id: resolveNpmImport(source), external: true} : null;
+}
+
 export function observable({
   window = new JSDOM().window,
   parser = new window.DOMParser(),
@@ -66,6 +71,8 @@ export function observable({
 }: ObservableOptions = {}): PluginOption {
   return {
     name: "observable",
+    enforce: "pre",
+    resolveId: resolveNpmId,
     buildStart() {
       this.addWatchFile(template);
     },


### PR DESCRIPTION
*This code and PR description is from a coding agent.*

## Summary

- Move `npm:` externalization from Vite's deprecated alias `customResolver` into the existing Observable plugin.
- Run the resolver as a pre hook, preserving Notebook Kit's build and preview composition where `plugins` is assigned after spreading `config()`.
- Add a focused test for plugin ordering, `npm:` resolution, externalization, and non-`npm:` fallthrough.

## Why

Vite 8 warns that alias `customResolver` is deprecated and will be removed in Vite 9. The recommended replacement is a plugin with a `resolveId` hook and `enforce: "pre"`.

Keeping the hook on `observable()` is important: Notebook Kit's build and preview commands replace the `plugins` property after spreading `config()`, so a separate plugin returned only by `config()` would be dropped.

## Validation

Using Node 24 and pnpm 10, matching CI:

- Red/green focused regression test
- Full test suite: 25 files, 222 tests passed
- `pnpm lint` (TypeScript and ESLint)
- `pnpm prepublishOnly`
- Complete `pnpm docs:build`; real `npm:` imports resolve and the deprecation warning is absent
- Packed-package consumer build with Vite 8.2.2; the build passes without the warning